### PR TITLE
Generate modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "src"
   ],
   "scripts": {
-    "build": "webpack --mode=production",
+    "build:es": "tsc",
+    "build": "yarn build:es && webpack --mode=production",
     "watch": "webpack --mode=development -w",
     "link-all": "yarn link protvista-interpro-adapter protvista-feature-adapter protvista-interpro-track protvista-filter protvista-manager protvista-navigation protvista-proteomics-adapter protvista-sequence protvista-structure-adapter protvista-tooltip protvista-track protvista-variation protvista-variation-adapter protvista-variation-graph protvista-zoomable protvista-datatable protvista-structure data-loader",
     "add-all": "yarn add protvista-feature-adapter protvista-filter protvista-manager protvista-navigation protvista-proteomics-adapter protvista-sequence protvista-structure-adapter protvista-tooltip protvista-track protvista-variation protvista-variation-adapter protvista-variation-graph protvista-zoomable protvista-datatable protvista-structure data-loader",
@@ -18,7 +19,7 @@
     "test": "npm-run-all --continue-on-error test:*"
   },
   "main": "dist/protvista-uniprot.js",
-  "module": "src/protvista-uniprot.js",
+  "module": "dist/es/protvista-uniprot.js",
   "keywords": [],
   "author": "Xavier Watkins &lt;xwatkins@ebi.ac.uk&gt;",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build:es": "tsc",
-    "build": "yarn build:es && webpack --mode=production",
+    "build": "webpack --mode=production && yarn build:es",
     "watch": "webpack --mode=development -w",
     "link-all": "yarn link protvista-interpro-adapter protvista-feature-adapter protvista-interpro-track protvista-filter protvista-manager protvista-navigation protvista-proteomics-adapter protvista-sequence protvista-structure-adapter protvista-tooltip protvista-track protvista-variation protvista-variation-adapter protvista-variation-graph protvista-zoomable protvista-datatable protvista-structure data-loader",
     "add-all": "yarn add protvista-feature-adapter protvista-filter protvista-manager protvista-navigation protvista-proteomics-adapter protvista-sequence protvista-structure-adapter protvista-tooltip protvista-track protvista-variation protvista-variation-adapter protvista-variation-graph protvista-zoomable protvista-datatable protvista-structure data-loader",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,11 @@ import ProtvistaUniprot from './protvista-uniprot';
 import DownloadPanel from './download-panel';
 import ProtvistaUniprotStructure from './protvista-uniprot-structure';
 
-import _transformDataFeatureAdapter from './protvista-uniprot';
-import _transformDataProteomicsAdapter from './protvista-uniprot';
-import _transformDataStructureAdapter from './protvista-uniprot';
-import _transformDataVariationAdapter from './protvista-uniprot';
-import _transformDataInterproAdapter from './protvista-uniprot';
+import { transformDataFeatureAdapter as _transformDataFeatureAdapter } from './protvista-uniprot';
+import { transformDataProteomicsAdapter as _transformDataProteomicsAdapter } from './protvista-uniprot';
+import { transformDataStructureAdapter as _transformDataStructureAdapter } from './protvista-uniprot';
+import { transformDataVariationAdapter as _transformDataVariationAdapter } from './protvista-uniprot';
+import { transformDataInterproAdapter as _transformDataInterproAdapter } from './protvista-uniprot';
 
 export const transformDataFeatureAdapter = _transformDataFeatureAdapter;
 export const transformDataProteomicsAdapter = _transformDataProteomicsAdapter;

--- a/src/protvista-uniprot.ts
+++ b/src/protvista-uniprot.ts
@@ -227,7 +227,7 @@ class ProtvistaUniprot extends LitElement {
       const uniqueUrls = [...new Set(urls)];
       // Get the data for all urls and store it
       await Promise.all(
-        uniqueUrls.map((url) =>
+        uniqueUrls.map((url: string) =>
           load(url.replace('{accession}', accession)).then(
             (data) => (this.rawData[url] = data.payload),
             // TODO handle this better based on error code

--- a/src/types/protvista-datatable.d.ts
+++ b/src/types/protvista-datatable.d.ts
@@ -8,7 +8,7 @@ type ColumnConfig<T> = {
 };
 
 declare class ProtvistaDatatable extends HTMLElement {
-  columns: ColumnConfig;
+  columns: ColumnConfig<any>;
   data: any[];
   rowClickEvent: (e) => void;
   selectedid?: string;

--- a/src/types/protvista-filter.d.ts
+++ b/src/types/protvista-filter.d.ts
@@ -11,6 +11,6 @@ declare class ProtvistaFilter extends HTMLElement {
       labels: string[];
       colors: string[];
     };
-    filterData: (data: any) => returnedData;
+    filterData: (data: any) => any;
   }[];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,28 +4,28 @@
 
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
-    "target": "esnext",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
-    "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "target": "es2019",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
+    // "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
-    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                         /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
+    "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    // "outDir": "./",                              /* Redirect output structure to the directory. */
+    "outDir": "./dist/es",                          /* Redirect output structure to the directory. */
     // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
     // "removeComments": true,                      /* Do not emit comments to output. */
-    "noEmit": true,                              /* Do not emit outputs. */
+    // "noEmit": true,                              /* Do not emit outputs. */
     // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                                 /* Enable all strict type-checking options. */
+    // "strict": true,                                 /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                    /* Enable strict null checks. */
     // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
@@ -44,14 +44,14 @@
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
     // "types": [],                                 /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    // "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
 
@@ -66,8 +66,8 @@
     // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "skipLibCheck": true,                           /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true,        /* Disallow inconsistently-cased references to the same file. */
+    // "skipLibCheck": true,                           /* Skip type checking of declaration files. */
+    // "forceConsistentCasingInFileNames": true,        /* Disallow inconsistently-cased references to the same file. */
     "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
### Reference to existing issue
ES modules were not transpiled (and tsconfig file was ignored as transpilation to commonjs was happening in babel).

### Description of changes
Added a script to use the TypeScript compiler and transpile the .ts files. Target is es2019 because of the use of flat(), I checked browsers on caniuse and I believe it should be ok

### Testing/Styleguide
 - [x] Tests pass
 - [x] Linters pass
