### PR TITLE
Interpro representative domain track

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
       <!-- Not all features -->
       <!-- <protvista-uniprot accession="P41892"></protvista-uniprot> -->
       <protvista-uniprot accession="P05067"></protvista-uniprot>
+      <!-- <protvista-uniprot accession="Q8WZ42"></protvista-uniprot> -->
       <!-- <protvista-uniprot accession="Q653S1"></protvista-uniprot> -->
       <!-- <protvista-uniprot accession="B9FXV5"></protvista-uniprot> -->
       <!-- <protvista-uniprot-structure

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
       <!-- Not all features -->
       <!-- <protvista-uniprot accession="P41892"></protvista-uniprot> -->
       <protvista-uniprot accession="P05067"></protvista-uniprot>
-      <!-- <protvista-uniprot accession="Q8WZ42"></protvista-uniprot> -->
+      <!-- PTM related -->
       <!-- <protvista-uniprot accession="Q653S1"></protvista-uniprot> -->
       <!-- <protvista-uniprot accession="B9FXV5"></protvista-uniprot> -->
       <!-- <protvista-uniprot-structure

--- a/src/config.json
+++ b/src/config.json
@@ -25,7 +25,7 @@
           "data": [
             {
               "adapter": "protvista-interpro-adapter",
-              "url": "https://www.ebi.ac.uk/interpro/api/entry/all/protein/uniprot/{accession}?type=domain"
+              "url": "https://www.ebi.ac.uk/interpro/api/entry/all/protein/uniprot/{accession}?type=domain&page_size=100"
             }
           ],
           "tooltip": "InterPro representative domains"

--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,18 @@
           "tooltip": "Specific combination of secondary structures organized into a characteristic three-dimensional structure or fold"
         },
         {
+          "name": "representative domain",
+          "label": "Representative Domain",
+          "trackType": "protvista-track",
+          "data": [
+            {
+              "adapter": "protvista-interpro-adapter",
+              "url": "https://www.ebi.ac.uk/interpro/api/entry/all/protein/uniprot/{accession}?type=domain"
+            }
+          ],
+          "tooltip": "InterPro representative domains"
+        },
+        {
           "name": "region",
           "label": "Region",
           "filter": "REGION",

--- a/src/config.json
+++ b/src/config.json
@@ -556,38 +556,6 @@
       ]
     },
     {
-      "name": "MUTAGENESIS",
-      "label": "Mutagenesis",
-      "trackType": "protvista-track",
-      "tracks": [
-        {
-          "name": "mutagen",
-          "label": "Mutagenesis",
-          "filter": "MUTAGEN",
-          "trackType": "protvista-track",
-          "data": [
-            {
-              "adapter": "protvista-feature-adapter",
-              "url": "https://www.ebi.ac.uk/proteins/api/features/{accession}"
-            }
-          ],
-          "tooltip": "Site which has been experimentally altered by mutagenesis"
-        },
-        {
-          "name": "othermutagen",
-          "label": "Other Mutagenesis",
-          "trackType": "protvista-track",
-          "data": [
-            {
-              "adapter": "protvista-feature-adapter",
-              "url": "https://www.ebi.ac.uk/proteins/api/mutagenesis/{accession}"
-            }
-          ],
-          "tooltip": "Site which has been experimentally altered by mutagenesis"
-        }
-      ]
-    },
-    {
       "name": "PROTEOMICS",
       "label": "Proteomics",
       "trackType": "protvista-track",
@@ -653,6 +621,38 @@
             }
           ],
           "tooltip": ""
+        }
+      ]
+    },
+    {
+      "name": "MUTAGENESIS",
+      "label": "Mutagenesis",
+      "trackType": "protvista-track",
+      "tracks": [
+        {
+          "name": "mutagen",
+          "label": "Mutagenesis",
+          "filter": "MUTAGEN",
+          "trackType": "protvista-track",
+          "data": [
+            {
+              "adapter": "protvista-feature-adapter",
+              "url": "https://www.ebi.ac.uk/proteins/api/features/{accession}"
+            }
+          ],
+          "tooltip": "Site which has been experimentally altered by mutagenesis"
+        },
+        {
+          "name": "othermutagen",
+          "label": "Other Mutagenesis",
+          "trackType": "protvista-track",
+          "data": [
+            {
+              "adapter": "protvista-feature-adapter",
+              "url": "https://www.ebi.ac.uk/proteins/api/mutagenesis/{accession}"
+            }
+          ],
+          "tooltip": "Site which has been experimentally altered by mutagenesis"
         }
       ]
     },

--- a/src/config.json
+++ b/src/config.json
@@ -19,8 +19,8 @@
           "tooltip": "Specific combination of secondary structures organized into a characteristic three-dimensional structure or fold"
         },
         {
-          "name": "representative domain",
-          "label": "Representative Domain",
+          "name": "InterPro representative domain",
+          "label": "InterPro Representative Domain",
           "trackType": "protvista-track",
           "data": [
             {

--- a/src/protvista-uniprot.ts
+++ b/src/protvista-uniprot.ts
@@ -213,13 +213,27 @@ class ProtvistaUniprot extends LitElement {
                 : trackData;
 
               if (adapter === 'protvista-interpro-adapter') {
-                transformedData = transformedData.filter(feature => {
-                  const [representative] = feature.locations.flatMap(loc => loc.fragments).flatMap(fragment => fragment.representative);
-                  if (representative) {
-                    return feature;
+                const representativeDomains = [];
+                transformedData.forEach(feature => {
+                  const fragments = feature.locations.flatMap(loc => loc.fragments).filter(fragment => fragment.representative);
+                  if (fragments.length) {
+                    fragments.forEach(fragment => {
+                      representativeDomains.push({...feature, start: fragment.start, end: fragment.end});
+                    });
                   }
                 });
+                transformedData = representativeDomains;
               }
+              // if (adapter === 'protvista-interpro-adapter') {
+              //   transformedData = transformedData.filter((feature) =>
+              //     feature.locations.some((location) =>
+              //       location.fragments.some(
+              //         (fragment) => fragment.representative
+              //       )
+              //     )
+              //   );
+              //   debugger
+              //   }
               
               // 2. Filter raw data if filter is specified
               const filteredData =

--- a/src/protvista-uniprot.ts
+++ b/src/protvista-uniprot.ts
@@ -214,27 +214,22 @@ class ProtvistaUniprot extends LitElement {
 
               if (adapter === 'protvista-interpro-adapter') {
                 const representativeDomains = [];
-                transformedData.forEach(feature => {
-                  const fragments = feature.locations.flatMap(loc => loc.fragments).filter(fragment => fragment.representative);
-                  if (fragments.length) {
-                    fragments.forEach(fragment => {
-                      representativeDomains.push({...feature, start: fragment.start, end: fragment.end});
-                    });
+                for (const feature of transformedData) {
+                  for (const location of feature.locations) {
+                    for (const fragment of location.fragments) {
+                      if (fragment.representative) {
+                        representativeDomains.push({
+                          ...feature,
+                          start: fragment.start,
+                          end: fragment.end,
+                        });
+                      }
+                    }
                   }
-                });
+                }
                 transformedData = representativeDomains;
               }
-              // if (adapter === 'protvista-interpro-adapter') {
-              //   transformedData = transformedData.filter((feature) =>
-              //     feature.locations.some((location) =>
-              //       location.fragments.some(
-              //         (fragment) => fragment.representative
-              //       )
-              //     )
-              //   );
-              //   debugger
-              //   }
-              
+
               // 2. Filter raw data if filter is specified
               const filteredData =
                 Array.isArray(transformedData) && filter

--- a/src/protvista-uniprot.ts
+++ b/src/protvista-uniprot.ts
@@ -214,15 +214,18 @@ class ProtvistaUniprot extends LitElement {
 
               if (adapter === 'protvista-interpro-adapter') {
                 const representativeDomains = [];
-                for (const feature of transformedData) {
-                  for (const location of feature.locations) {
-                    for (const fragment of location.fragments) {
-                      if (fragment.representative) {
-                        representativeDomains.push({
-                          ...feature,
-                          start: fragment.start,
-                          end: fragment.end,
-                        });
+                if (transformedData) {
+                  for (const feature of transformedData) {
+                    for (const location of feature.locations) {
+                      for (const fragment of location.fragments) {
+                        if (fragment.representative) {
+                          representativeDomains.push({
+                            ...feature,
+                            type: 'InterPro Representative Domain',
+                            start: fragment.start,
+                            end: fragment.end,
+                          });
+                        }
                       }
                     }
                   }

--- a/src/protvista-uniprot.ts
+++ b/src/protvista-uniprot.ts
@@ -37,7 +37,8 @@ export const transformDataProteomicsAdapter = _transformDataProteomicsAdapter;
 export const transformDataStructureAdapter = _transformDataStructureAdapter;
 export const transformDataVariationAdapter = _transformDataVariationAdapter;
 export const transformDataInterproAdapter = _transformDataInterproAdapter;
-export const transformDataProteomicsPTMApdapter = _transformDataProteomicsPTMApdapter;
+export const transformDataProteomicsPTMApdapter =
+  _transformDataProteomicsPTMApdapter;
 export const filterConfig = _filterConfig;
 export const colorConfig = _colorConfig;
 export const ProtvistaUniprotStructure = _ProtvistaUniprotStructure;
@@ -49,7 +50,7 @@ const adapters = {
   'protvista-proteomics-adapter': transformDataProteomicsAdapter,
   'protvista-structure-adapter': transformDataStructureAdapter,
   'protvista-variation-adapter': transformDataVariationAdapter,
-  'protvista-proteomics-ptm-adapter': transformDataProteomicsPTMApdapter
+  'protvista-proteomics-ptm-adapter': transformDataProteomicsPTMApdapter,
 };
 
 type TrackType =
@@ -69,7 +70,8 @@ type ProtvistaTrackConfig = {
       | 'protvista-feature-adapter'
       | 'protvista-structure-adapter'
       | 'protvista-proteomics-adapter'
-      | 'protvista-variation-adapter';
+      | 'protvista-variation-adapter'
+      | 'protvista-interpro-adapter';
   }[];
   tooltip: string;
   color?: string;
@@ -204,11 +206,21 @@ class ProtvistaUniprot extends LitElement {
               ) {
                 return;
               }
+
               // 1. Convert data
-              const transformedData = adapter
+              let transformedData = adapter
                 ? adapters[adapter](trackData)
                 : trackData;
 
+              if (adapter === 'protvista-interpro-adapter') {
+                transformedData = transformedData.filter(feature => {
+                  const [representative] = feature.locations.flatMap(loc => loc.fragments).flatMap(fragment => fragment.representative);
+                  if (representative) {
+                    return feature;
+                  }
+                });
+              }
+              
               // 2. Filter raw data if filter is specified
               const filteredData =
                 Array.isArray(transformedData) && filter


### PR DESCRIPTION
### Reference to existing issue
https://www.ebi.ac.uk/panda/jira/browse/TRM-30366
https://www.ebi.ac.uk/panda/jira/browse/TRM-26336

Nightingale:
https://www.ebi.ac.uk/panda/jira/browse/TRM-30524

### Description of changes
Changes include 
- updating protvista-interpro-adpater in Nightingale for tootip and color scheme for representative track
- Reorder mutagenesis track in the config

Nightingale:
Variation schema update for genomicLocation from string to string[]
Eg: P21802. Variant at G>R at pos 182

### Testing/Styleguide
 - [ ] Tests pass
 - [ ] Linters pass
