### PR TITLE
implement alphamissense track and filtering out out-of-sync sequences

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,11 +24,16 @@
 
   <body>
     <div>
+      <!-- Good default -->
+      <!-- <protvista-uniprot accession="P05067"></protvista-uniprot> -->
       <!-- No features -->
       <!-- <protvista-uniprot accession="A0A2K5ULD0"></protvista-uniprot> -->
       <!-- Not all features -->
       <!-- <protvista-uniprot accession="P41892"></protvista-uniprot> -->
-      <protvista-uniprot accession="P05067"></protvista-uniprot>
+      <!-- Out of date alphafold -->
+      <!-- <protvista-uniprot accession="O75319"></protvista-uniprot> -->
+      <!-- AlphaMissense data -->
+      <protvista-uniprot accession="P07550"></protvista-uniprot>
       <!-- PTM related -->
       <!-- <protvista-uniprot accession="Q653S1"></protvista-uniprot> -->
       <!-- <protvista-uniprot accession="B9FXV5"></protvista-uniprot> -->

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -17,6 +17,8 @@ export type AlphafoldPayload = Array<{
   cifUrl?: string;
   bcifUrl?: string;
   amAnnotationsUrl?: string;
+  amAnnotationsHg19Url?: string;
+  amAnnotationsHg38Url?: string;
   pdbUrl: string;
   paeImageUrl: string;
   paeDocUrl: string;

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -1,0 +1,23 @@
+export type AlphafoldPayload = Array<{
+  entryId: string;
+  gene: string;
+  uniprotAccession: string;
+  uniprotId: string;
+  uniprotDescription: string;
+  taxId: number;
+  organismScientificName: string;
+  uniprotStart: number;
+  uniprotEnd: number;
+  uniprotSequence: string;
+  modelCreatedDate: string;
+  latestVersion: number;
+  allVersions: number[];
+  isReviewed: boolean;
+  isReferenceProteome: boolean;
+  cifUrl?: string;
+  bcifUrl?: string;
+  amAnnotationsUrl?: string;
+  pdbUrl: string;
+  paeImageUrl: string;
+  paeDocUrl: string;
+}>;

--- a/src/config.json
+++ b/src/config.json
@@ -216,7 +216,7 @@
           "tooltip": "Extent of a region located in a membrane without crossing it"
         }
       ]
-    },  
+    },
     {
       "name": "DOMAINS",
       "label": "Domains",
@@ -332,7 +332,6 @@
           ],
           "tooltip": "Any interesting single amino acid site on the sequence"
         },
-        
         {
           "name": "ca_bind",
           "label": "Calcium binding",
@@ -639,10 +638,38 @@
           "data": [
             {
               "adapter": "protvista-alphafold-confidence-adapter",
-              "url": "https://alphafold.ebi.ac.uk/api/prediction/{accession}"
+              "url": [
+                "https://alphafold.ebi.ac.uk/api/prediction/{accession}",
+                "https://www.ebi.ac.uk/proteins/api/proteins/{accession}"
+              ]
             }
           ],
           "tooltip": "AlphaFold prediction confidence"
+        }
+      ]
+    },
+    {
+      "name": "ALPHAMISSENSE_PATHOGENICITY",
+      "label": "AlphaMissense",
+      "trackType": "protvista-coloured-sequence",
+      "scale": "P:100,A:50,B:0",
+      "color-range": "#9a131a:100,#a8a9ad:50,#3d5493:0",
+      "tracks": [
+        {
+          "name": "alphamissense_pathogenicity",
+          "label": "AlphaMissense Pathogenicity",
+          "labelUrl": "https://alphafold.ebi.ac.uk/entry/{accession}",
+          "trackType": "protvista-coloured-sequence",
+          "data": [
+            {
+              "adapter": "protvista-alphamissense-pathogenicity-adapter",
+              "url": [
+                "https://alphafold.ebi.ac.uk/api/prediction/{accession}",
+                "https://www.ebi.ac.uk/proteins/api/proteins/{accession}"
+              ]
+            }
+          ],
+          "tooltip": "AlphaMissense prediction pathogenicity"
         }
       ]
     },

--- a/src/protvista-alphafold-confidence.ts
+++ b/src/protvista-alphafold-confidence.ts
@@ -1,24 +1,4 @@
-type AlphafoldPayload = Array<{
-  entryId: string;
-  gene: string;
-  uniprotAccession: string;
-  uniprotId: string;
-  uniprotDescription: string;
-  taxId: number;
-  organismScientificName: string;
-  uniprotStart: number;
-  uniprotEnd: number;
-  uniprotSequence: string;
-  modelCreatedDate: string;
-  latestVersion: number;
-  allVersions: number[];
-  cifUrl?: string;
-  bcifUrl?: string;
-  amAnnotationsUrl?: string;
-  pdbUrl: string;
-  paeImageUrl: string;
-  paeDocUrl: string;
-}>;
+import { AlphafoldPayload } from './commonTypes';
 
 type AlphafoldConfidencePayload = {
   residueNumber: Array<number>;

--- a/src/protvista-alphafold-confidence.ts
+++ b/src/protvista-alphafold-confidence.ts
@@ -12,8 +12,9 @@ type AlphafoldPayload = Array<{
   modelCreatedDate: string;
   latestVersion: number;
   allVersions: number[];
-  cifUrl: string;
-  bcifUrl: string;
+  cifUrl?: string;
+  bcifUrl?: string;
+  amAnnotationsUrl?: string;
   pdbUrl: string;
   paeImageUrl: string;
   paeDocUrl: string;
@@ -43,9 +44,19 @@ const loadConfidence = async (
   }
 };
 
-export const transformData = async (data: AlphafoldPayload) => {
+type PartialProtein = {
+  sequence: {
+    sequence: string;
+  };
+};
+
+export const transformData = async (
+  data: AlphafoldPayload,
+  protein: PartialProtein
+) => {
   const confidenceUrl = getConfidenceURLFromPayload(data);
-  if (confidenceUrl) {
+  const { uniprotSequence } = data?.[0] || {};
+  if (confidenceUrl && uniprotSequence === protein.sequence.sequence) {
     const confidenceData = await loadConfidence(confidenceUrl);
     return confidenceData?.confidenceCategory.join('');
   }

--- a/src/protvista-alphamissense-pathogenicity.ts
+++ b/src/protvista-alphamissense-pathogenicity.ts
@@ -1,24 +1,4 @@
-type AlphafoldPayload = Array<{
-  entryId: string;
-  gene: string;
-  uniprotAccession: string;
-  uniprotId: string;
-  uniprotDescription: string;
-  taxId: number;
-  organismScientificName: string;
-  uniprotStart: number;
-  uniprotEnd: number;
-  uniprotSequence: string;
-  modelCreatedDate: string;
-  latestVersion: number;
-  allVersions: number[];
-  cifUrl?: string;
-  bcifUrl?: string;
-  amAnnotationsUrl?: string;
-  pdbUrl: string;
-  paeImageUrl: string;
-  paeDocUrl: string;
-}>;
+import { AlphafoldPayload } from './commonTypes';
 
 // from example data
 // benign: [0.0448,0.3397]: x < 0.34
@@ -93,10 +73,7 @@ const parseCSV = (rawText: string): string => {
 // Load and parse
 const loadAndParseAnnotations = async (url: string): Promise<string> => {
   try {
-    const payload = await fetch(
-      // Temporary, to cope with test data endpoint, remove after PR review
-      `https://corsproxy.io?${encodeURIComponent(url)}`
-    );
+    const payload = await fetch(url);
     const rawCSV = await payload.text();
     return parseCSV(rawCSV);
   } catch (e) {

--- a/src/protvista-alphamissense-pathogenicity.ts
+++ b/src/protvista-alphamissense-pathogenicity.ts
@@ -1,5 +1,3 @@
-import mockData from './AF-P07550-F1-aa-substitutions';
-
 type AlphafoldPayload = Array<{
   entryId: string;
   gene: string;
@@ -121,7 +119,5 @@ export const transformData = async (
     const variationData = await loadAndParseAnnotations(amAnnotationsUrl);
     // return confidenceData?.confidenceCategory.join('');
     return variationData;
-  } else {
-    return parseCSV(mockData);
   }
 };

--- a/src/protvista-alphamissense-pathogenicity.ts
+++ b/src/protvista-alphamissense-pathogenicity.ts
@@ -1,0 +1,127 @@
+import mockData from './AF-P07550-F1-aa-substitutions';
+
+type AlphafoldPayload = Array<{
+  entryId: string;
+  gene: string;
+  uniprotAccession: string;
+  uniprotId: string;
+  uniprotDescription: string;
+  taxId: number;
+  organismScientificName: string;
+  uniprotStart: number;
+  uniprotEnd: number;
+  uniprotSequence: string;
+  modelCreatedDate: string;
+  latestVersion: number;
+  allVersions: number[];
+  cifUrl?: string;
+  bcifUrl?: string;
+  amAnnotationsUrl?: string;
+  pdbUrl: string;
+  paeImageUrl: string;
+  paeDocUrl: string;
+}>;
+
+// from example data
+// benign: [0.0448,0.3397]: x < 0.34
+// ambiguous: [0.34,0.564]: 0.34 <= x <= 0.564
+// pathogenic: [0.5646,0.9999]: 0.564 < x
+const benign = 0.34;
+const pathogenic = 0.564;
+
+const rowSplitter = /\s*\n\s*/;
+const cellSplitter = /^(.)(\d+)(.),(.+),(\w+)$/;
+
+type Row = {
+  wildType: string;
+  position: number;
+  mutated: string;
+  pathogenicityScore: number;
+  pathogenicityLabel: string;
+};
+
+const parseCSV = (rawText: string): string => {
+  const positions: Array<Array<Row>> = [];
+  for (const [i, row] of rawText.split(rowSplitter).entries()) {
+    if (i === 0 || !row) {
+      continue;
+    }
+    const [
+      ,
+      wildType,
+      positionString,
+      mutated,
+      pathogenicityScore,
+      pathogenicityLabel,
+    ] = row.match(cellSplitter);
+    const position = +positionString;
+    const index = position - 1;
+    if (!positions[index]) {
+      positions[index] = [];
+    }
+    positions[index].push({
+      wildType,
+      position,
+      mutated,
+      pathogenicityScore: +pathogenicityScore,
+      pathogenicityLabel,
+    });
+  }
+
+  const out = [];
+  for (const position of positions) {
+    let letter = 'A';
+    // maximum
+    // const value = Math.max(
+    //   ...position.map((variation) => variation.pathogenicityScore)
+    // );
+    // average
+    const value =
+      position.reduce(
+        (acc, variation) => acc + +variation.pathogenicityScore,
+        0
+      ) / position.length;
+    if (value > pathogenic) {
+      letter = 'P';
+    } else if (value < benign) {
+      letter = 'B';
+    }
+    out.push(letter);
+  }
+
+  return out.join('');
+};
+
+// Load and parse
+const loadAndParseAnnotations = async (url: string): Promise<string> => {
+  try {
+    const payload = await fetch(
+      // Temporary, to cope with test data endpoint, remove after PR review
+      `https://corsproxy.io?${encodeURIComponent(url)}`
+    );
+    const rawCSV = await payload.text();
+    return parseCSV(rawCSV);
+  } catch (e) {
+    console.error('Could not load AlphaMissense pathogenicity', e);
+  }
+};
+
+type PartialProtein = {
+  sequence: {
+    sequence: string;
+  };
+};
+
+export const transformData = async (
+  data: AlphafoldPayload,
+  protein: PartialProtein
+) => {
+  const { amAnnotationsUrl, uniprotSequence } = data?.[0] || {};
+  if (amAnnotationsUrl && uniprotSequence === protein.sequence.sequence) {
+    const variationData = await loadAndParseAnnotations(amAnnotationsUrl);
+    // return confidenceData?.confidenceCategory.join('');
+    return variationData;
+  } else {
+    return parseCSV(mockData);
+  }
+};


### PR DESCRIPTION
### Reference to existing issue
https://www.ebi.ac.uk/panda/jira/browse/TRM-31097 & https://www.ebi.ac.uk/panda/jira/browse/TRM-31098
Add AlphaMissense data in a coloured track & ignore AlphaFold and AlphaMissense data if sequence is out-of-sync

### Description of changes
- Add way to download multiple data endpoints for 1 track directly from the config
- match sequence data in Proteins API and AlphaFoldDB API in order to determine if predictions are out-of-sync with the sequence
- Add logic to download and parse AlphaMissense CSV data
- Use the coloured track to display AlphaMissense average pathogenicity score

### Testing/Styleguide
 - [ ] Tests pass
 - [ ] Linters pass
