### PR TITLE
Move tooltip logic to separate file and export AA mapping modification

### DIFF
--- a/src/tooltips/featureTooltip.ts
+++ b/src/tooltips/featureTooltip.ts
@@ -1,4 +1,5 @@
 import ecoMap from '../adapters/config/evidence';
+import { phosphorylate, sumoylate } from './ptmTooltip';
 
 const taxIdToPeptideAtlasBuildData = {
   '36329': { build: '542', organism: 'Plasmodium' },
@@ -98,27 +99,14 @@ const formatPTMPeptidoform = (peptide, ptms) => {
   return peptidoform;
 };
 
-// Amino acids for Phosphorylation modification
-const AAPhosphoSites = {
-  A: 'alanine',
-  S: 'serine',
-  T: 'threonine',
-  Y: 'tyrosine',
-};
-
-// Amino acids for SUMOylation modification
-const AASumoSites = {
-  K: 'lysine',
-};
-
 const findModifiedResidueName = (feature, ptm) => {
   const { peptide, begin: peptideStart } = feature;
   const proteinLocation = Number(peptideStart) + ptm.position - 1;
   const modifiedResidue = peptide.charAt(ptm.position - 1); // CharAt index starts from 0
   if (ptm.name === 'Phosphorylation') {
-    return `${proteinLocation} phospho${AAPhosphoSites[modifiedResidue]}`;
+    return `${proteinLocation} ${phosphorylate(modifiedResidue)}`;
   } else if (ptm.name === 'SUMOylation') {
-    return `${proteinLocation} Sumoylated ${AASumoSites[modifiedResidue]}`;
+    return `${proteinLocation} ${sumoylate(modifiedResidue)}`;
   }
   return '';
 };

--- a/src/tooltips/ptmTooltip.ts
+++ b/src/tooltips/ptmTooltip.ts
@@ -1,0 +1,86 @@
+import { PTM } from "../adapters/ptm-exchange-adapter";
+
+type Modification = 'Phosphorylation' | 'SUMOylation';
+
+const aaToPhosphorylated = {
+  R: 'Phosphoarginine',
+  C: 'Phosphocysteine',
+  H: 'Phosphohistidine',
+  S: 'Phosphoserine',
+  T: 'Phosphothreonine',
+  Y: 'Phosphotyrosine',
+};
+
+const aaToSumoylated = {
+  K: 'Sumoylated lysine',
+};
+
+export const phosphorylate = (aa: string) => {
+  const AA = aa.toUpperCase();
+  if (AA in aaToPhosphorylated) {
+    return aaToPhosphorylated[AA as keyof typeof aaToPhosphorylated];
+  }
+  console.error(`${AA} not a valid amino acid for phosphorylation`);
+  return '';
+};
+
+export const sumoylate = (aa: string) => {
+  const AA = aa.toUpperCase();
+  if (AA in aaToSumoylated) {
+    return aaToSumoylated[AA as keyof typeof aaToSumoylated];
+  }
+  console.error(`${AA} not a valid amino acid for SUMOylation`);
+  return '';
+};
+
+const formatTooltip = (ptms: PTM[], aa: string, confidenceScore: string): string => {
+    const evidences = [
+        ...ptms.flatMap(({ dbReferences }) =>
+          dbReferences?.flatMap(({ id }) => [id])
+        ),
+      ];
+   
+      let modification: Modification | undefined;
+      const modifications = new Set(ptms.flatMap(({name}) => name as Modification));
+      if (modifications.size) {
+        if (modifications.size > 1) {
+          console.error(
+            `PTMeXchange PTM has a mixture of modifications: ${Array.from(
+              modifications
+            )}`
+          );
+        } else {
+          [modification] = modifications;
+        }
+      }
+      
+  return `
+  <h5>Description</h5><p>${
+    modification === 'Phosphorylation' ? phosphorylate(aa) : sumoylate(aa)
+  }</p>
+  ${
+    confidenceScore
+      ? `<h5 data-article-id="mod_res_large_scale#confidence-score">Confidence Score</h5><p>${confidenceScore}</p>`
+      : ''
+  }
+  ${
+    evidences
+      ? `<h5>Evidence</h5><ul class="no-bullet">${evidences
+          .map((id) => {
+            const datasetID = id === 'Glue project' ? 'PXD012174' : id;
+            return `<li title='${datasetID}' style="padding: .25rem 0">${datasetID}&nbsp;
+              (<a href="https://proteomecentral.proteomexchange.org/dataset/${datasetID}" style="color:#FFF" target="_blank">ProteomeXchange</a>)
+              </li>
+              ${
+                id === 'Glue project'
+                  ? `<li title="publication" style="padding: .25rem 0">Publication:&nbsp;31819260&nbsp;(<a href="https://pubmed.ncbi.nlm.nih.gov/31819260" style="color:#FFF" target="_blank">PubMed</a>)</li>`
+                  : ''
+              }
+              `;
+          })
+          .join('')}</ul>`
+      : ''
+  }`;
+};
+
+export default formatTooltip;


### PR DESCRIPTION
### Reference to existing issue
https://www.ebi.ac.uk/panda/jira/browse/TRM-32428

### Description of changes
Remove two different AA mappings to phosphorylation and export the correct one instead. 
Move tooltip logic to tooltips folder where the rest of them are. 

### Testing/Styleguide
 - [ ] Tests pass
 - [ ] Linters pass
