### PR TITLE
Enable structure viewer to load provided only sequence checksum

### DIFF
--- a/src/protvista-uniprot-structure.ts
+++ b/src/protvista-uniprot-structure.ts
@@ -229,6 +229,9 @@ const process3DBeaconsData = (
         summary.provider === 'isoform.io'
           ? 'https://www.isoform.io/home'
           : summary.model_page_url,
+      chain:
+        summary.entities?.flatMap((entity) => entity.chain_ids).join(', ') ||
+        undefined,
     })) || []
   );
 };


### PR DESCRIPTION
### Reference to existing issue
Structure viewer supports checksum
If given accession and not checksum, it fetches PDBe, AF and 3d-beacons using the accession. (default UniProtKB case)
If given only checksum, it fetches models from 3d-beacons only and sorts by `confidence_avg_local_score`. (UPI000012C942)
When both checksum and accession are given (in case of uniparc xref), it queries 3d-beacons using checksum and sorts the results with the accession given at the top. (UPI000012C942/A0A6H2GIB5)

### Description of changes

### Testing/Styleguide
 - [ ] Tests pass
 - [ ] Linters pass
