### PR TITLE
Type filter predicates and colorConfig to eliminate `any` in filter-config (toward #133)

### DIFF
--- a/src/__spec__/filter-config.spec.ts
+++ b/src/__spec__/filter-config.spec.ts
@@ -99,7 +99,7 @@ const transformedVariantPositions = [
 describe('Variation filter config', () => {
   test('it should filter according to the callback function', () => {
     const filteredVariants = getFilteredVariants(
-      transformedVariantPositions as VariantsForFilter,
+      transformedVariantPositions as unknown as VariantsForFilter,
       (variant) => variant.accession === 'A'
     );
     expect(filteredVariants).toEqual([

--- a/src/filter-config.ts
+++ b/src/filter-config.ts
@@ -1,6 +1,8 @@
 import { VariationDatum } from '@nightingale-elements/nightingale-variation';
 import { ClinicalSignificance } from '@nightingale-elements/nightingale-variation';
 
+import { TransformedVariant } from './adapters/variation-adapter';
+
 const scaleColors = {
   UPDiseaseColor: '#990000',
   UPNonDiseaseColor: '#99cc00',
@@ -21,12 +23,12 @@ const significanceMatches = (
   });
 
 export type VariantsForFilter = {
-  variants: VariationDatum[];
+  variants: TransformedVariant[];
 }[];
 
 export const getFilteredVariants = (
   variants: VariantsForFilter,
-  callbackFilter: (variantPos: VariationDatum) => void
+  callbackFilter: (variantPos: TransformedVariant) => unknown
 ) =>
   variants.map((variant) => {
     const matchingVariants = variant.variants.filter((variantPos) =>
@@ -38,7 +40,9 @@ export const getFilteredVariants = (
     };
   });
 
-const filterPredicates = {
+type FilterPredicate = (variantPos: TransformedVariant) => unknown;
+
+const filterPredicates: Record<string, FilterPredicate> = {
   disease: (variantPos) =>
     variantPos.association?.some((association) => association.disease),
   predicted: (variantPos) => variantPos.hasPredictions,
@@ -170,7 +174,7 @@ const filterConfig = [
 
 const countVariantsForFilter = (
   filterName: 'disease' | 'nonDisease' | 'uncertain' | 'predicted',
-  variant: VariationDatum
+  variant: TransformedVariant
 ) => {
   const variantWrapper: VariantsForFilter = [{ variants: [variant] }];
   const filter = filterConfig.find((filter) => filter.name === filterName);
@@ -180,14 +184,21 @@ const countVariantsForFilter = (
   return false;
 };
 
-export const colorConfig = (variant: any) => {
-  if (countVariantsForFilter('disease', variant)) {
+/**
+ * Signature matches Nightingale's `NightingaleVariation.colorConfig`
+ * (`(v: VariationDatum) => string`). At runtime ProtVista always assigns
+ * transformed variants (VariationDatum & Variant), so the branches can safely
+ * read the extra fields after the narrowing cast to `TransformedVariant`.
+ */
+export const colorConfig = (variant: VariationDatum): string => {
+  const transformed = variant as TransformedVariant;
+  if (countVariantsForFilter('disease', transformed)) {
     return scaleColors.UPDiseaseColor;
-  } else if (countVariantsForFilter('nonDisease', variant)) {
+  } else if (countVariantsForFilter('nonDisease', transformed)) {
     return scaleColors.UPNonDiseaseColor;
-  } else if (countVariantsForFilter('uncertain', variant)) {
+  } else if (countVariantsForFilter('uncertain', transformed)) {
     return scaleColors.othersColor;
-  } else if (countVariantsForFilter('predicted', variant)) {
+  } else if (countVariantsForFilter('predicted', transformed)) {
     return scaleColors.predictedColor;
   }
   return scaleColors.othersColor;


### PR DESCRIPTION
## Purpose

Incremental step toward #133 — eliminate implicit and explicit `any` from `src/`. This PR narrows the scope to **`src/filter-config.ts`** and its unit test only.

Under `tsc --noImplicitAny --strictNullChecks` this file produces **9 implicit-`any` errors** (on the `filterPredicates` callbacks and the two inner `association` callbacks). It also carries the single explicit `any` on the exported `colorConfig`. This PR eliminates all 10.

## Approach

- The `filterPredicates` callbacks receive, at runtime, the transformed variants produced by `./adapters/variation-adapter` (`TransformedVariant = VariationDatum & Variant`) — e.g. they read `association`, `clinicalSignificances`, `sourceType`, which are on `Variant` but not on `VariationDatum`. The `any` was previously masking this mismatch.
- Introduce a local `FilterPredicate` alias and tighten `filterPredicates`, `VariantsForFilter`, `getFilteredVariants`'s callback, and `countVariantsForFilter`'s `variant` parameter to `TransformedVariant`.
- Keep the exported `colorConfig` signature as `(variant: VariationDatum) => string` so it remains assignable to `NightingaleVariation.colorConfig` (used at `src/protvista-uniprot.ts:327`). The narrowing `TransformedVariant` cast is localised to `colorConfig`'s body and documented inline.
- The existing unit test already uses `transformedVariantPositions as VariantsForFilter`. With `VariantsForFilter` now demanding the richer shape, that single-step cast no longer structurally overlaps (hand-built mocks are intentionally minimal, e.g. `begin: number` instead of `string`). Upgrade it to `as unknown as VariantsForFilter` — the TypeScript-recommended form — which preserves the test's intent without changing test data or runtime behaviour.

Per the issue's guidance to land this incrementally, `noImplicitAny`/`strictNullChecks` and the `@typescript-eslint/no-explicit-any` rule are **not** flipped on yet — that belongs in the closing PR after every directory has been cleaned.

## Testing

- `npx eslint src --ext .ts` — clean.
- `npx tsc --noEmit --noImplicitAny --strictNullChecks` — all 9 previously reported errors from `src/filter-config.ts` are gone; no new errors surfaced anywhere else (total project errors: 98 → 89).
- `npx vitest run src/__spec__/filter-config.spec.ts` — 5/5 tests pass (all four `colorConfig` colour-per-variant assertions plus the `getFilteredVariants` callback test).
- `npx vite build` — successful; declaration emission and bundle unchanged.

## Visual changes

None — type-system-only change.

## Checklist

- [x] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] If needed, the changes have been previewed by all interested parties.
