### PR TITLE
Type renameProperties generically to eliminate implicit `any` in utils (toward #133)

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,8 @@
-export const renameProperties = (features) =>
+type FeatureWithBegin = { begin?: string | number };
+
+export const renameProperties = <T extends FeatureWithBegin>(
+  features: T[]
+): Array<T & { start: string | number | undefined }> =>
   features.map((ft) => ({
     ...ft,
     start: ft.begin || undefined,


### PR DESCRIPTION
## Purpose

Incremental step toward #133 — eliminate implicit and explicit `any` from `src/`. Continuing the small-PR approach from #138, this PR narrows the scope to **`src/utils/index.ts`** only.

Under `tsc --noImplicitAny --strictNullChecks`, both parameters of `renameProperties` were implicitly typed as `any`:

```
src/utils/index.ts(1,34): error TS7006: Parameter 'features' implicitly has an 'any' type.
src/utils/index.ts(2,17): error TS7006: Parameter 'ft' implicitly has an 'any' type.
```

## What this PR does

- Introduces a local `FeatureWithBegin` type capturing the only shape assumption the function body actually makes about its input (an optional `begin` field of type `string | number`).
- Makes `renameProperties` generic in `T extends FeatureWithBegin`, so every other property on the caller's feature shape is preserved on the returned objects. No downstream type information is lost.

## What this PR does not do

- No runtime changes. The function body is byte-for-byte identical.
- No changes to callers (`src/adapters/feature-adapter.ts`, `src/adapters/proteomics-adapter.ts`). Both still pass untyped data in for now; that is left to a follow-up PR that tightens the adapters themselves.
- No changes to `tsconfig.json` / ESLint config yet.

## Verification

```
tsc --noImplicitAny --strictNullChecks   # src/utils: 0 errors (was 2)
eslint src/utils/index.ts                # clean
vite build                               # OK
vitest run                               # 4 files / 60 tests, all pass
```

## Follow-ups (separate PRs)

- `src/adapters/**` implicit-any cleanup (largest cluster)
- `src/tooltips/**` implicit-any cleanup
- `src/protvista-uniprot.ts` — the central adapter dispatch map (`Record<string, (...args: any[]) => any>`) and the `NightingaleEvent` detail shape
- Closing PR: enable `noImplicitAny: true`, `strictNullChecks: true`, and `@typescript-eslint/no-explicit-any: 'error'` once the tree is clean

## Testing checklist

- [x] I have tested the changes locally (`vite build`, `vitest run`)
- [x] The change has no runtime impact (types only)
- [x] The diff is minimal and scoped to a single file

<!-- No related screenshots: type-level refactor only. -->
