### PR TITLE
No table option

### DIFF
--- a/src/__spec__/protvista-uniprot-structure-empty.spec.ts
+++ b/src/__spec__/protvista-uniprot-structure-empty.spec.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@nightingale-elements/nightingale-structure', () => {
+  class MockNightingaleStructure extends HTMLElement {}
+  return { default: MockNightingaleStructure };
+});
+
+vi.mock('../utils', async () => {
+  const actual =
+    await vi.importActual<typeof import('../utils')>('../utils');
+  return {
+    ...actual,
+    fetchAll: vi.fn(),
+  };
+});
+
+import { fetchAll } from '../utils';
+import '../protvista-uniprot-structure';
+import type ProtvistaUniprotStructure from '../protvista-uniprot-structure';
+import type { ProcessedStructureData } from '../protvista-uniprot-structure';
+
+const mockedFetchAll = fetchAll as unknown as ReturnType<typeof vi.fn>;
+
+const emptyFetchAll = async (urls: string[]) =>
+  Object.fromEntries(urls.map((u) => [u, null]));
+
+const flushMicrotasks = async () => {
+  // Two passes is enough for fetchAll's resolution callback to run and
+  // for the subsequent dispatchEvent to land.
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const waitForEventOrFlush = async (
+  el: HTMLElement,
+  listener: ReturnType<typeof vi.fn>
+) => {
+  await flushMicrotasks();
+  // updateComplete is on LitElement; settle Lit's reactive cycle too.
+  await (el as unknown as { updateComplete: Promise<unknown> }).updateComplete;
+  await flushMicrotasks();
+  return listener;
+};
+
+const createElementWith = (
+  attrs: { accession?: string; checksum?: string; noTable?: boolean } = {}
+) => {
+  const el = document.createElement(
+    'protvista-uniprot-structure'
+  ) as ProtvistaUniprotStructure;
+  if (attrs.accession) el.setAttribute('accession', attrs.accession);
+  if (attrs.checksum) el.setAttribute('checksum', attrs.checksum);
+  if (attrs.noTable) el.setAttribute('no-table', '');
+  return el;
+};
+
+describe('<protvista-uniprot-structure> structures-loaded event', () => {
+  beforeEach(() => {
+    mockedFetchAll.mockReset();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('dispatches structures-loaded with [] when the merged result is empty', async () => {
+    mockedFetchAll.mockImplementation(emptyFetchAll);
+
+    const el = createElementWith({ accession: 'P00000', noTable: true });
+    const listener = vi.fn();
+    el.addEventListener('structures-loaded', listener);
+    document.body.appendChild(el);
+
+    await waitForEventOrFlush(el, listener);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock
+      .calls[0][0] as CustomEvent<ReadonlyArray<ProcessedStructureData>>;
+    expect(Array.isArray(event.detail)).toBe(true);
+    expect(event.detail).toHaveLength(0);
+    expect(el.data).toEqual([]);
+    expect(el.selectedId).toBeUndefined();
+    expect(
+      (el as unknown as { loading?: boolean }).loading
+    ).toBe(false);
+  });
+
+  it('dispatches structures-loaded exactly once for a non-empty payload', async () => {
+    mockedFetchAll.mockImplementation(async (urls: string[]) => {
+      const [pdbUrl, alphaFoldUrl, beaconsUrl] = urls;
+      return {
+        [pdbUrl]: {
+          uniProtKBCrossReferences: [
+            {
+              database: 'PDB',
+              id: '1ABC',
+              properties: [
+                { key: 'Method', value: 'X-ray' },
+                { key: 'Resolution', value: '2.0 A' },
+                { key: 'Chains', value: 'A=1-100' },
+              ],
+            },
+          ],
+        },
+        [alphaFoldUrl]: null,
+        [beaconsUrl]: null,
+      };
+    });
+
+    const el = createElementWith({ accession: 'P00001', noTable: true });
+    const listener = vi.fn();
+    el.addEventListener('structures-loaded', listener);
+    document.body.appendChild(el);
+
+    await waitForEventOrFlush(el, listener);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock
+      .calls[0][0] as CustomEvent<ReadonlyArray<ProcessedStructureData>>;
+    expect(event.detail).toHaveLength(1);
+    expect(event.detail[0]).toMatchObject({ id: '1ABC', source: 'PDB' });
+    expect(el.selectedId).toBe('1ABC');
+  });
+
+  it('respects a consumer-preset selectedId when payload is empty', async () => {
+    mockedFetchAll.mockImplementation(emptyFetchAll);
+
+    const el = createElementWith({ accession: 'P00002', noTable: true });
+    el.selectedId = 'foo';
+    const listener = vi.fn();
+    el.addEventListener('structures-loaded', listener);
+    document.body.appendChild(el);
+
+    await waitForEventOrFlush(el, listener);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(el.selectedId).toBe('foo');
+  });
+
+  it('does not dispatch when accession and checksum are both missing', async () => {
+    mockedFetchAll.mockImplementation(emptyFetchAll);
+
+    const el = createElementWith();
+    const listener = vi.fn();
+    el.addEventListener('structures-loaded', listener);
+    document.body.appendChild(el);
+
+    await waitForEventOrFlush(el, listener);
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(mockedFetchAll).not.toHaveBeenCalled();
+  });
+
+  it('renders the "No structure information available" message for an empty payload with no-table absent', async () => {
+    mockedFetchAll.mockImplementation(emptyFetchAll);
+
+    const el = createElementWith({ accession: 'P00003' });
+    const listener = vi.fn();
+    el.addEventListener('structures-loaded', listener);
+    document.body.appendChild(el);
+
+    await waitForEventOrFlush(el, listener);
+
+    expect(el.textContent).toContain('No structure information available');
+  });
+
+  it('does not render the internal data table for an empty payload', async () => {
+    mockedFetchAll.mockImplementation(emptyFetchAll);
+
+    const el = createElementWith({ accession: 'P00004' });
+    const listener = vi.fn();
+    el.addEventListener('structures-loaded', listener);
+    document.body.appendChild(el);
+
+    await waitForEventOrFlush(el, listener);
+
+    expect(el.querySelector('protvista-uniprot-datatable')).toBeNull();
+  });
+});

--- a/src/adapters/feature-adapter.ts
+++ b/src/adapters/feature-adapter.ts
@@ -5,13 +5,13 @@ const transformData = (data: { features?: Record<string, unknown>[] }) => {
   let transformedData: Record<string, unknown>[] = [];
   const { features } = data;
   if (features && features.length > 0) {
-    transformedData = features.map((feature) => {
-      return {
-        ...feature,
-        tooltipContent: formatTooltip(feature),
-      };
-    });
-    transformedData = renameProperties(transformedData);
+    // Rename `begin` to `start` first so formatTooltip can read the unified
+    // field name regardless of the upstream wire format.
+    const renamed = renameProperties(features);
+    transformedData = renamed.map((feature) => ({
+      ...feature,
+      tooltipContent: formatTooltip(feature),
+    }));
   }
   return transformedData;
 };

--- a/src/adapters/proteomics-adapter.ts
+++ b/src/adapters/proteomics-adapter.ts
@@ -20,10 +20,13 @@ const proteomicsTrackProperties = (feature: ProteomicsFeature, taxId: number) =>
 };
 
 const transformData = (data: ProteomicsData) => {
-  let adaptedData: (ProteomicsFeature & { start?: number })[] = [];
+  let adaptedData: ProteomicsFeature[] = [];
 
   if (data && data.features && data.features.length !== 0) {
-    adaptedData = data.features.map((feature) => {
+    // Rename `begin` to `start` first so formatTooltip (called inside
+    // proteomicsTrackProperties) can read the unified field name.
+    const renamed = renameProperties(data.features) as ProteomicsFeature[];
+    adaptedData = renamed.map((feature) => {
       feature.residuesToHighlight = feature.ptms?.map((ptm) => ({
         name: ptm.name,
         position: ptm.position,
@@ -35,8 +38,6 @@ const transformData = (data: ProteomicsData) => {
         proteomicsTrackProperties(feature, data.taxid)
       );
     });
-
-    adaptedData = renameProperties(adaptedData) as typeof adaptedData;
   }
   return adaptedData;
 };

--- a/src/adapters/variation-adapter.ts
+++ b/src/adapters/variation-adapter.ts
@@ -26,15 +26,22 @@ const transformData = (
   variants: TransformedVariant[];
 } | null => {
   const { sequence, features } = data;
-  const variants = features.map((variant) => ({
-    ...variant,
-    accession: variant.genomicLocation?.join(', ') ?? '',
-    variant: variant.alternativeSequence || AminoAcid.Empty,
-    start: +variant.begin,
-    xrefNames: getSourceType(variant.xrefs, variant.sourceType),
-    hasPredictions: !!(variant.predictions && variant.predictions.length > 0),
-    tooltipContent: formatTooltip(variant),
-  }));
+  const variants = features.map((variant) => {
+    // Build the transformed shape first (with `start`) so formatTooltip can
+    // read the unified field name rather than the wire-format `begin`.
+    const transformed = {
+      ...variant,
+      accession: variant.genomicLocation?.join(', ') ?? '',
+      variant: variant.alternativeSequence || AminoAcid.Empty,
+      start: +variant.begin,
+      xrefNames: getSourceType(variant.xrefs, variant.sourceType),
+      hasPredictions: !!(variant.predictions && variant.predictions.length > 0),
+    };
+    return {
+      ...transformed,
+      tooltipContent: formatTooltip(transformed),
+    };
+  });
   if (!variants) return null;
   return { sequence, variants };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,6 @@ export { default as getFeatureTooltip } from './tooltips/feature-tooltip';
 export { default as getStructureTooltip } from './tooltips/structure-tooltip';
 export { default as getVariationTooltip } from './tooltips/variation-tooltip';
 export { default as ProtvistaUniprotStructure } from './protvista-uniprot-structure';
+export type { ProcessedStructureData } from './protvista-uniprot-structure';
 import ProtvistaUniprot from './protvista-uniprot';
 export default ProtvistaUniprot;

--- a/src/protvista-uniprot-datatable.ts
+++ b/src/protvista-uniprot-datatable.ts
@@ -487,3 +487,5 @@ declare global {
     >;
   }
 }
+
+export default ProtvistaUniprotDatatable;

--- a/src/protvista-uniprot-structure.ts
+++ b/src/protvista-uniprot-structure.ts
@@ -585,13 +585,11 @@ class ProtvistaUniprotStructure extends LitElement {
 
     const data = [...pdbData, ...uniqueAFData, ...beaconsNonAFData];
 
-    if (!data || !data.length) return;
-
     this.data = data;
     this.columns = this.getColumns();
 
     // Default to the first row only if the consumer hasn't pre-set a selection.
-    if (!this.selectedId) {
+    if (data.length > 0 && !this.selectedId) {
       this.selectedId = data[0].id;
     }
 
@@ -818,7 +816,7 @@ class ProtvistaUniprotStructure extends LitElement {
                     ${svg`${unsafeHTML(loaderIcon)}`}
                   </div>`
                 : nothing}
-              ${!this.data && !this.loading
+              ${(!this.data || this.data.length === 0) && !this.loading
                 ? html`<div class="protvista-no-results">
                     No structure information available
                     ${this.accession ? `for ${this.accession}` : ''}

--- a/src/protvista-uniprot-structure.ts
+++ b/src/protvista-uniprot-structure.ts
@@ -391,14 +391,15 @@ class ProtvistaUniprotStructure extends LitElement {
   constructor() {
     super();
     loadComponent('nightingale-structure', NightingaleStructure);
+    // Registered unconditionally (even when no-table is set) so the import is
+    // preserved through tree-shaking; the element only renders when noTable is
+    // false, so an unused registration is cheap.
     loadComponent('protvista-uniprot-datatable', ProtvistaUniprotDatatable);
 
     this.loading = true;
     this.addStyles();
     this.colorTheme = 'alphafold';
     this.alphamissenseAvailable = false;
-
-    this.columns = this.getColumns();
   }
 
   static get properties() {
@@ -627,14 +628,30 @@ class ProtvistaUniprotStructure extends LitElement {
   protected override willUpdate(changed: PropertyValues) {
     // Apply when either selection or data changes — covers consumer
     // pre-setting selected-id before the async fetch resolves.
-    if (
-      (changed.has('selectedId') || changed.has('data')) &&
-      this.data &&
-      this.selectedId
-    ) {
-      const row = this.data.find((r) => r.id === this.selectedId);
-      if (row) this.applySelection(row);
+    if (!changed.has('selectedId') && !changed.has('data')) return;
+    // Wait for the first data assignment before deciding what to show; a
+    // consumer-set selectedId arriving before fetch should not clear anything.
+    if (!this.data) return;
+
+    const row = this.selectedId
+      ? this.data.find((r) => r.id === this.selectedId)
+      : undefined;
+    if (row) {
+      this.applySelection(row);
+    } else {
+      // No match (empty data, stale selectedId, or selection cleared) — drop
+      // the viewer state so a previous structure does not linger on screen.
+      this.clearViewer();
     }
+  }
+
+  private clearViewer() {
+    // No-op when nothing was ever applied — avoids handing Mol* an undefined
+    // ref on the initial-load empty-data path.
+    if (!this.structureId && !this.modelUrl) return;
+    this.structureId = undefined;
+    this.modelUrl = '';
+    this.metaInfo = undefined;
   }
 
   private applySelection(row: ProcessedStructureData) {

--- a/src/protvista-uniprot-structure.ts
+++ b/src/protvista-uniprot-structure.ts
@@ -1,11 +1,20 @@
-import { LitElement, html, svg, type TemplateResult, css, nothing } from 'lit';
+import {
+  LitElement,
+  html,
+  svg,
+  type TemplateResult,
+  type PropertyValues,
+  css,
+  nothing,
+} from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import NightingaleStructure, {
   type AlphaFoldPayload,
 } from '@nightingale-elements/nightingale-structure';
-import type { ColumnConfig } from './protvista-uniprot-datatable';
-import './protvista-uniprot-datatable';
+import ProtvistaUniprotDatatable, {
+  type ColumnConfig,
+} from './protvista-uniprot-datatable';
 import { fetchAll, loadComponent } from './utils';
 import downloadIcon from './icons/download.svg';
 import externalLinkIcon from './icons/external-link.svg';
@@ -117,7 +126,7 @@ type BeaconsData = {
   }[];
 };
 
-type ProcessedStructureData = {
+export type ProcessedStructureData = {
   id: string;
   source: string;
   method?: string;
@@ -128,7 +137,8 @@ type ProcessedStructureData = {
   sourceDBLink?: string;
   protvistaFeatureId: string;
   amAnnotationsUrl?: string;
-  isoform?: TemplateResult;
+  isoformId?: string;
+  isoformIsCanonical?: boolean;
   afPrediction?: boolean; // Flag to differentiate the structure source as AlphaFold prediction API vs 3DBeacons AlphaFold
 };
 
@@ -193,7 +203,6 @@ const processPDBData = (data: UniProtKBData): ProcessedStructureData[] =>
 
 const processAFData = (
   data: AlphaFoldPayload,
-  accession?: string,
   isoforms?: IsoformIdSequence,
   canonicalSequence?: string
 ): ProcessedStructureData[] =>
@@ -203,15 +212,6 @@ const processAFData = (
         ({ sequence }) => d.sequence === sequence
       );
 
-      const isoformElement = isoformMatch
-        ? html`<a
-            href="${uniprotKBUrl}${accession}/entry#${isoformMatch.isoformId}"
-          >
-            ${isoformMatch.isoformId}
-            ${isoformMatch.sequence === canonicalSequence ? '(Canonical)' : ''}
-          </a>`
-        : undefined;
-
       return {
         id: d.modelEntityId,
         source: 'AlphaFold DB',
@@ -220,7 +220,10 @@ const processAFData = (
         protvistaFeatureId: d.modelEntityId,
         downloadUrl: d.pdbUrl,
         amAnnotationsUrl: d.amAnnotationsUrl,
-        isoform: isoformElement,
+        isoformId: isoformMatch?.isoformId,
+        isoformIsCanonical: isoformMatch
+          ? isoformMatch.sequence === canonicalSequence
+          : undefined,
         afPrediction: true,
       };
     })
@@ -384,11 +387,13 @@ class ProtvistaUniprotStructure extends LitElement {
   private modelUrl = '';
 
   private columns: ColumnConfig<ProcessedStructureData>[] = [];
-  private selectedRowId?: string;
+  selectedId?: string;
+  noTable?: boolean;
 
   constructor() {
     super();
     loadComponent('nightingale-structure', NightingaleStructure);
+    loadComponent('protvista-uniprot-datatable', ProtvistaUniprotDatatable);
 
     this.loading = true;
     this.addStyles();
@@ -409,6 +414,8 @@ class ProtvistaUniprotStructure extends LitElement {
       colorTheme: { type: String },
       alphamissenseAvailable: { type: Boolean },
       isoforms: { type: Object, attribute: false },
+      selectedId: { type: String, attribute: 'selected-id' },
+      noTable: { type: Boolean, attribute: 'no-table' },
     };
   }
 
@@ -426,8 +433,17 @@ class ProtvistaUniprotStructure extends LitElement {
     if (this.isoforms) {
       cols.push({
         label: 'Isoform',
-        key: 'isoform',
-        render: (row) => row.isoform ?? nothing,
+        key: 'isoformId',
+        render: (row) =>
+          row.isoformId
+            ? html`<a
+                href="${uniprotKBUrl}${this.accession}/entry#${row.isoformId}"
+              >
+                ${row.isoformId}${row.isoformIsCanonical
+                  ? ' (Canonical)'
+                  : ''}
+              </a>`
+            : nothing,
       });
     }
 
@@ -524,7 +540,6 @@ class ProtvistaUniprotStructure extends LitElement {
 
       afData = processAFData(
         alphaFoldSequenceMatches,
-        this.accession,
         this.isoforms,
         rawData[pdbUrl]?.sequence?.value
       );
@@ -575,9 +590,21 @@ class ProtvistaUniprotStructure extends LitElement {
     this.data = data;
     this.columns = this.getColumns();
 
-    // Select first row by default
-    this.selectedRowId = data[0].id;
-    this.onRowSelected(data[0]);
+    // Default to the first row only if the consumer hasn't pre-set a selection.
+    if (!this.selectedId) {
+      this.selectedId = data[0].id;
+    }
+
+    this.dispatchEvent(
+      new CustomEvent<ReadonlyArray<ProcessedStructureData>>(
+        'structures-loaded',
+        {
+          detail: data,
+          bubbles: true,
+          composed: true,
+        }
+      )
+    );
   }
 
   disconnectedCallback() {
@@ -601,9 +628,21 @@ class ProtvistaUniprotStructure extends LitElement {
     document.getElementById(styleId)?.remove();
   }
 
-  private onRowSelected(row: ProcessedStructureData) {
+  protected override willUpdate(changed: PropertyValues) {
+    // Apply when either selection or data changes — covers consumer
+    // pre-setting selected-id before the async fetch resolves.
+    if (
+      (changed.has('selectedId') || changed.has('data')) &&
+      this.data &&
+      this.selectedId
+    ) {
+      const row = this.data.find((r) => r.id === this.selectedId);
+      if (row) this.applySelection(row);
+    }
+  }
+
+  private applySelection(row: ProcessedStructureData) {
     const { id, source, downloadUrl, amAnnotationsUrl, afPrediction } = row;
-    this.selectedRowId = id;
 
     if (
       this.checksum ||
@@ -630,7 +669,7 @@ class ProtvistaUniprotStructure extends LitElement {
   }
 
   private onDatatableRowClick = (e: CustomEvent<ProcessedStructureData>) => {
-    this.onRowSelected(e.detail);
+    this.selectedId = e.detail.id;
   };
 
   get cssStyle() {
@@ -761,30 +800,32 @@ class ProtvistaUniprotStructure extends LitElement {
             : nothing}
         </div>
 
-        <div class="protvista-uniprot-structure__table">
-          ${this.data && this.data.length
-            ? html`
-                <protvista-uniprot-datatable
-                  .data=${this.data}
-                  .columns=${this.columns}
-                  .selectedId=${this.selectedRowId}
-                  row-id-key="id"
-                  @row-click=${this.onDatatableRowClick}
-                ></protvista-uniprot-datatable>
-              `
-            : nothing}
-          ${this.loading
-            ? html`<div class="protvista-loader">
-                ${svg`${unsafeHTML(loaderIcon)}`}
-              </div>`
-            : nothing}
-          ${!this.data && !this.loading
-            ? html`<div class="protvista-no-results">
-                No structure information available
-                ${this.accession ? `for ${this.accession}` : ''}
-              </div>`
-            : nothing}
-        </div>
+        ${!this.noTable
+          ? html`<div class="protvista-uniprot-structure__table">
+              ${this.data && this.data.length
+                ? html`
+                    <protvista-uniprot-datatable
+                      .data=${this.data}
+                      .columns=${this.columns}
+                      .selectedId=${this.selectedId}
+                      row-id-key="id"
+                      @row-click=${this.onDatatableRowClick}
+                    ></protvista-uniprot-datatable>
+                  `
+                : nothing}
+              ${this.loading
+                ? html`<div class="protvista-loader">
+                    ${svg`${unsafeHTML(loaderIcon)}`}
+                  </div>`
+                : nothing}
+              ${!this.data && !this.loading
+                ? html`<div class="protvista-no-results">
+                    No structure information available
+                    ${this.accession ? `for ${this.accession}` : ''}
+                  </div>`
+                : nothing}
+            </div>`
+          : nothing}
       </div>
     `;
   }

--- a/src/protvista-uniprot-structure.ts
+++ b/src/protvista-uniprot-structure.ts
@@ -142,12 +142,10 @@ export type ProcessedStructureData = {
   afPrediction?: boolean; // Flag to differentiate the structure source as AlphaFold prediction API vs 3DBeacons AlphaFold
 };
 
-type IsoformIdSequence = [
-  {
-    isoformId: string;
-    sequence: string;
-  },
-];
+type IsoformIdSequence = Array<{
+  isoformId: string;
+  sequence: string;
+}>;
 
 const getIsoformNum = (s: string) => {
   const match = s.match(/-(\d+)-F1$/);

--- a/src/protvista-uniprot-structure.ts
+++ b/src/protvista-uniprot-structure.ts
@@ -438,9 +438,7 @@ class ProtvistaUniprotStructure extends LitElement {
             ? html`<a
                 href="${uniprotKBUrl}${this.accession}/entry#${row.isoformId}"
               >
-                ${row.isoformId}${row.isoformIsCanonical
-                  ? ' (Canonical)'
-                  : ''}
+                ${row.isoformId}${row.isoformIsCanonical ? ' (Canonical)' : ''}
               </a>`
             : nothing,
       });
@@ -813,8 +811,9 @@ class ProtvistaUniprotStructure extends LitElement {
             : nothing}
         </div>
 
-        ${!this.noTable
-          ? html`<div class="protvista-uniprot-structure__table">
+        ${this.noTable
+          ? nothing
+          : html`<div class="protvista-uniprot-structure__table">
               ${this.data && this.data.length
                 ? html`
                     <protvista-uniprot-datatable
@@ -837,8 +836,7 @@ class ProtvistaUniprotStructure extends LitElement {
                     ${this.accession ? `for ${this.accession}` : ''}
                   </div>`
                 : nothing}
-            </div>`
-          : nothing}
+            </div>`}
       </div>
     `;
   }

--- a/src/protvista-uniprot.ts
+++ b/src/protvista-uniprot.ts
@@ -180,8 +180,8 @@ class ProtvistaUniprot extends LitElement {
   private rawData: Record<string, TrackPayload> = {};
   private displayCoordinates: { start?: number; end?: number } = {};
   private suspend?: boolean;
-  accession?: string;
-  sequence?: string;
+  private accession?: string;
+  private sequence?: string;
   private notooltip?: boolean;
   private transformedVariants?: {
     sequence: string;

--- a/src/protvista-uniprot.ts
+++ b/src/protvista-uniprot.ts
@@ -52,7 +52,10 @@ import { StructureFeature } from './adapters/structure-adapter';
 type TrackPayload =
   | Record<string, unknown>[]
   | { sequence: string; variants: TransformedVariant[] }
-  | { sequence: string; variants: TransformedVariant[] } & Record<string, unknown>
+  | ({ sequence: string; variants: TransformedVariant[] } & Record<
+      string,
+      unknown
+    >)
   | TransformedInterPro
   | StructureFeature[]
   | { variants?: TransformedVariant[] }
@@ -115,25 +118,41 @@ async function callAdapter(
     case 'interpro-adapter':
       return interproAdapter(...(raw as Parameters<typeof interproAdapter>));
     case 'proteomics-adapter':
-      return proteomicsAdapter(...(raw as Parameters<typeof proteomicsAdapter>));
+      return proteomicsAdapter(
+        ...(raw as Parameters<typeof proteomicsAdapter>)
+      );
     case 'structure-adapter':
       return structureAdapter(...(raw as Parameters<typeof structureAdapter>));
     case 'variation-adapter':
       return variationAdapter(...(raw as Parameters<typeof variationAdapter>));
     case 'variation-graph-adapter':
-      return variationGraphAdapter(...(raw as Parameters<typeof variationGraphAdapter>));
+      return variationGraphAdapter(
+        ...(raw as Parameters<typeof variationGraphAdapter>)
+      );
     case 'rna-editing-adapter':
-      return rnaEditingAdapter(...(raw as Parameters<typeof rnaEditingAdapter>));
+      return rnaEditingAdapter(
+        ...(raw as Parameters<typeof rnaEditingAdapter>)
+      );
     case 'rna-editing-graph-adapter':
-      return rnaEditingGraphAdapter(...(raw as Parameters<typeof rnaEditingGraphAdapter>));
+      return rnaEditingGraphAdapter(
+        ...(raw as Parameters<typeof rnaEditingGraphAdapter>)
+      );
     case 'proteomics-ptm-adapter':
-      return proteomicsPTMApdapter(...(raw as Parameters<typeof proteomicsPTMApdapter>));
+      return proteomicsPTMApdapter(
+        ...(raw as Parameters<typeof proteomicsPTMApdapter>)
+      );
     case 'alphafold-confidence-adapter':
-      return alphaFoldConfidenceAdapter(...(raw as Parameters<typeof alphaFoldConfidenceAdapter>));
+      return alphaFoldConfidenceAdapter(
+        ...(raw as Parameters<typeof alphaFoldConfidenceAdapter>)
+      );
     case 'alphamissense-pathogenicity-adapter':
-      return alphaMissensePathogenicityAdapter(...(raw as Parameters<typeof alphaMissensePathogenicityAdapter>));
+      return alphaMissensePathogenicityAdapter(
+        ...(raw as Parameters<typeof alphaMissensePathogenicityAdapter>)
+      );
     case 'alphamissense-heatmap-adapter':
-      return alphaMissenseHeatmapAdapter(...(raw as Parameters<typeof alphaMissenseHeatmapAdapter>));
+      return alphaMissenseHeatmapAdapter(
+        ...(raw as Parameters<typeof alphaMissenseHeatmapAdapter>)
+      );
     default: {
       const _exhaustive: never = name;
       throw new Error(`Unknown adapter: ${_exhaustive as string}`);
@@ -161,8 +180,9 @@ class ProtvistaUniprot extends LitElement {
   private rawData: Record<string, TrackPayload> = {};
   private displayCoordinates: { start?: number; end?: number } = {};
   private suspend?: boolean;
-  private accession?: string;
-  private sequence?: string;
+  accession?: string;
+  sequence?: string;
+  private notooltip?: boolean;
   private transformedVariants?: {
     sequence: string;
     variants: TransformedVariant[];
@@ -264,7 +284,9 @@ class ProtvistaUniprot extends LitElement {
 
             if (
               !trackData ||
-              (adapter === 'variation-adapter' && Array.isArray(trackData[0]) && trackData[0].length === 0)
+              (adapter === 'variation-adapter' &&
+                Array.isArray(trackData[0]) &&
+                trackData[0].length === 0)
             ) {
               return;
             }
@@ -310,7 +332,10 @@ class ProtvistaUniprot extends LitElement {
             this.data[`${categoryName}-${trackName}`] = filteredData;
 
             if (trackName === 'variation') {
-              this.transformedVariants = filteredData as { sequence: string; variants: TransformedVariant[] };
+              this.transformedVariants = filteredData as {
+                sequence: string;
+                variants: TransformedVariant[];
+              };
             }
             return filteredData;
           })
@@ -347,7 +372,10 @@ class ProtvistaUniprot extends LitElement {
       const currentCategory = this.config?.categories.find(
         ({ name }) => name === id
       );
-      const dataAsArray = data as { length?: number; variants?: TransformedVariant[] } | null;
+      const dataAsArray = data as {
+        length?: number;
+        variants?: TransformedVariant[];
+      } | null;
       if (
         currentCategory &&
         currentCategory.tracks &&
@@ -356,7 +384,8 @@ class ProtvistaUniprot extends LitElement {
         // NOTE: should refactor variation-adapter
         // to return a list of variants and set the sequence
         // on protvista-variation separately
-        ((dataAsArray.length ?? 0) > 0 || (dataAsArray.variants?.length ?? 0) > 0)
+        ((dataAsArray.length ?? 0) > 0 ||
+          (dataAsArray.variants?.length ?? 0) > 0)
       ) {
         // Make category element visible
         const categoryElt = document.getElementById(
@@ -370,7 +399,9 @@ class ProtvistaUniprot extends LitElement {
             `track-${id}-${track.name}`
           ) as NightingaleTrackCanvas | null;
           if (elementTrack) {
-            elementTrack.data = this.data[`${id}-${track.name}`] as NightingaleTrackCanvas['data'];
+            elementTrack.data = this.data[
+              `${id}-${track.name}`
+            ] as NightingaleTrackCanvas['data'];
           }
         }
       }
@@ -386,7 +417,11 @@ class ProtvistaUniprot extends LitElement {
                 'nightingale-sequence-heatmap'
               );
             if (heatmapComponent && this.sequence) {
-              const heatmapData = this.data[`${id}-${track.name}`] as { xValue: number; yValue: string; score: number }[];
+              const heatmapData = this.data[`${id}-${track.name}`] as {
+                xValue: number;
+                yValue: string;
+                score: number;
+              }[];
               const xDomain = Array.from(
                 { length: this.sequence.length },
                 (_, i) => i + 1
@@ -394,7 +429,13 @@ class ProtvistaUniprot extends LitElement {
               const yDomain = [
                 ...new Set(heatmapData.map((hotMapItem) => hotMapItem.yValue)),
               ] as string[];
-              heatmapComponent.setHeatmapData(xDomain, yDomain, heatmapData as Parameters<typeof heatmapComponent.setHeatmapData>[2]);
+              heatmapComponent.setHeatmapData(
+                xDomain,
+                yDomain,
+                heatmapData as Parameters<
+                  typeof heatmapComponent.setHeatmapData
+                >[2]
+              );
               heatmapComponent.updateComplete.then(() => {
                 heatmapComponent.heatmapInstance?.setColor((d) =>
                   amColorScale(d.score)
@@ -436,7 +477,9 @@ class ProtvistaUniprot extends LitElement {
     );
 
     if (variationComponent && variationComponent?.colorConfig !== colorConfig) {
-      variationComponent.colorConfig = colorConfig as (v: import('@nightingale-elements/nightingale-variation').VariationDatum) => string;
+      variationComponent.colorConfig = colorConfig as (
+        v: import('@nightingale-elements/nightingale-variation').VariationDatum
+      ) => string;
     }
 
     if (changedProperties.has('suspend')) {
@@ -479,11 +522,13 @@ class ProtvistaUniprot extends LitElement {
     });
   }
 
-  async loadEntry(accession: string): Promise<{ sequence: { sequence: string } } | undefined> {
+  async loadEntry(
+    accession: string
+  ): Promise<{ sequence: { sequence: string } } | undefined> {
     try {
-      return await (
+      return (await (
         await fetch(`https://www.ebi.ac.uk/proteins/api/proteins/${accession}`)
-      ).json() as { sequence: { sequence: string } };
+      ).json()) as { sequence: { sequence: string } };
     } catch (e) {
       console.error(`Couldn't load UniProt entry`, e);
       return undefined;
@@ -731,10 +776,14 @@ class ProtvistaUniprot extends LitElement {
     if (selectedFilters) {
       const selectedConsequenceFilters = selectedFilters
         .map((f: string) => this.getFilter(consequenceFilters, f))
-        .filter(Boolean) as (Filter & { filterPredicate: (v: TransformedVariant) => unknown })[];
+        .filter(Boolean) as (Filter & {
+        filterPredicate: (v: TransformedVariant) => unknown;
+      })[];
       const selectedProvenanceFilters = selectedFilters
         .map((f: string) => this.getFilter(provenanceFilters, f))
-        .filter(Boolean) as (Filter & { filterPredicate: (v: TransformedVariant) => unknown })[];
+        .filter(Boolean) as (Filter & {
+        filterPredicate: (v: TransformedVariant) => unknown;
+      })[];
 
       const filteredVariants = this.transformedVariants?.variants
         ?.filter((variant) =>
@@ -750,7 +799,9 @@ class ProtvistaUniprot extends LitElement {
 
       const existing = this.data['VARIATION-variation'];
       this.data['VARIATION-variation'] = {
-        ...(existing && typeof existing === 'object' && !Array.isArray(existing) ? existing : {}),
+        ...(existing && typeof existing === 'object' && !Array.isArray(existing)
+          ? existing
+          : {}),
         variants: filteredVariants,
       } as TrackPayload;
 

--- a/src/tooltips/feature-tooltip.ts
+++ b/src/tooltips/feature-tooltip.ts
@@ -76,7 +76,7 @@ type PTMHighlight = {
 
 export type TooltipFeature = {
   type?: string;
-  begin?: string | number;
+  start?: string | number;
   end?: string | number;
   description?: string;
   ftId?: string;
@@ -193,7 +193,7 @@ const formatProformaWithLink = (proforma = '') => {
 };
 
 const findModifiedResidueName = (feature: TooltipFeature, ptm: PTMHighlight) => {
-  const { peptide, begin: peptideStart } = feature;
+  const { peptide, start: peptideStart } = feature;
   const proteinLocation = Number(peptideStart) + ptm.position - 1;
   const modifiedResidue = (peptide ?? '').charAt(ptm.position - 1); // CharAt index starts from 0
   switch (ptm.name) {
@@ -246,8 +246,8 @@ const formatTooltip = (feature: TooltipFeature, taxId?: string) => {
   try {
     return `
         ${
-          feature.type && feature.begin && feature.end
-            ? `<h4>${escapeHtml(feature.type)} ${escapeHtml(feature.begin)}-${escapeHtml(feature.end)}</h4><hr />`
+          feature.type && feature.start && feature.end
+            ? `<h4>${escapeHtml(feature.type)} ${escapeHtml(feature.start)}-${escapeHtml(feature.end)}</h4><hr />`
             : ''
         }
         ${description ? `<h5>Description</h5><p>${escapeHtml(description)}</p>` : ``}

--- a/src/tooltips/variation-tooltip.ts
+++ b/src/tooltips/variation-tooltip.ts
@@ -86,11 +86,13 @@ const getPredictions = (predictions: Prediction[]): string => {
     .join('');
 };
 
-const formatTooltip = (variant: Variant): string =>
+type VariantWithStart = Variant & { start?: number | string };
+
+const formatTooltip = (variant: VariantWithStart): string =>
   `
   ${
-    variant.type && variant.begin && variant.end
-      ? `<h4>${escapeHtml(variant.type)} ${escapeHtml(variant.begin)}-${escapeHtml(variant.end)}</h4><hr />`
+    variant.type && variant.start && variant.end
+      ? `<h4>${escapeHtml(variant.type)} ${escapeHtml(variant.start)}-${escapeHtml(variant.end)}</h4><hr />`
       : ''
   }
   <h5>Variant</h5><p>${escapeHtml(variant.wildType)} > ${


### PR DESCRIPTION
## Purpose

Adapt `<protvista-uniprot-structure>` for an external React consumer to render its own data.

## Approach

- New properties on `<protvista-uniprot-structure>`:
  - `no-table` / `noTable` — the component no longer renders its internal `<protvista-uniprot-datatable>`, loader, or empty-state message.
  - `selected-id` / `selectedId` — reactive property that drives the viewer; defaults to the first row only if the consumer hasn't pre-set it.
  - `structures-loaded` event (`CustomEvent<ReadonlyArray<ProcessedStructureData>>`, `bubbles + composed`) — fires once after fetch resolution, with `detail: []` when nothing was found.
- `ProcessedStructureData` is now exported from the package root, with the rendered `isoform: TemplateResult` field replaced by raw `isoformId` / `isoformIsCanonical` (the `<a>` is built inside the column renderer).
- Selection is centralised in a `willUpdate` hook: when `selectedId` or `data` changes the viewer either applies the matching row or clears its state, so stale selections don't linger.
- `protvista-uniprot-datatable` is explicitly registered + default-exported so it survives tree-shaking when consumers only import the structure component.
- `IsoformIdSequence` was typed as a single-element tuple, corrected to a real array.
- Added the missing `notooltip` field declaration on `ProtvistaUniprot` (already in the reactive-properties bag).

## Testing

- Created new test file `protvista-uniprot-structure-empty.spec.ts` for the case of empty payloads
- 
## Visual changes

None, new behavior is opt-in via `no-table`.

## Breaking changes

- `ProcessedStructureData.isoform` (a `TemplateResult`) is removed in favour of `isoformId: string` + `isoformIsCanonical: boolean`. The type was not previously exported, so no external consumers are affected; internal callers of `processAFData` no longer need to pass `accession`.
- The `structures-loaded` event now fires on empty results with `detail: []`. This is a new behavior, no prior contract to break

## Checklist

- [x] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] If needed, the changes have been previewed by all interested parties.
