### PR TITLE
Refactor: avoid hardcoding the variant filter to a track named . Data…

### DIFF
--- a/docs/security-config-id-keys.md
+++ b/docs/security-config-id-keys.md
@@ -1,0 +1,125 @@
+# Security hardening: config `id`s used as object-map keys
+
+This note documents a **low-severity, defense-in-depth** hardening item in the
+data loader: config-supplied group/track `id`s are written verbatim as keys into
+a plain-object map without a character allowlist. It was surfaced during the
+security review of the *"de-hardcode the variation filter baseline"* change (the
+`transformedVariants` → `__unfiltered` refactor that resolved
+[`architecture-audit.md` B3 / #156](./architecture-audit.md)). The finding is
+**pre-existing** — it is not introduced by that change — and is filed here rather
+than as an exploitable vulnerability report (see [Disclosure](#disclosure)).
+
+## Summary
+
+`loadProtvistaData` accumulates fetched/adapted per-track and per-group data into
+a plain object:
+
+```ts
+const data: Record<string, unknown> = {}; // src/load-data.ts
+```
+
+Keys are derived from config `id`s. Per-track keys are **composite**
+(`${groupId}-${trackId}`, plus the `${…}__unfiltered` baseline), so they can
+never equal a magic property name. The **group aggregate**, however, is written
+under a **bare** `groupId`:
+
+```ts
+// src/load-data.ts — group-aggregate assignment
+data[groupId] =
+  group.component === 'nightingale-linegraph-track' ||
+  group.component === 'nightingale-colored-sequence'
+    ? groupData[0]
+    : groupData.flat();
+```
+
+The schema places no character constraint on ids —
+`src/schema/schema.json` declares both group and track `id` as
+`{ "type": "string", "minLength": 1 }` with no `pattern`, and
+`src/schema/normalize.ts` validates only for **duplicate** ids, not for
+dangerous id *values*. So a group whose `id` is `__proto__` produces
+`data['__proto__'] = <array>`.
+
+## Mechanics — what actually happens
+
+This is **not** classic global `Object.prototype` pollution. Assigning
+`o['__proto__'] = someArray` on a plain object invokes the inherited `__proto__`
+setter and reparents `o`'s `[[Prototype]]`; it does not create an own property
+and does not mutate the shared `Object.prototype`. There is no recursive,
+attacker-keyed deep merge anywhere in the pipeline (`obj[userKey1][userKey2] = v`),
+which is what a real prototype-pollution vector requires.
+
+Consequences of a `__proto__` group id are therefore limited and contained:
+
+1. The affected group's aggregate value lands in the prototype slot instead of a
+   readable own key, so that one group renders incorrectly (an availability /
+   integrity bug for a hostile config, not a cross-object compromise).
+2. The reparenting is on the loader's transient local `data`. The component then
+   does `this.data = { ...this.data, ...data }`, which copies own-enumerable
+   properties only, so the reparenting is discarded at that boundary and never
+   reaches `this.data`.
+
+### Related hazard: key-namespace collisions
+
+Because keys are string-concatenated without a reserved separator, unconstrained
+ids also permit silent collisions that corrupt rendering (not a security risk,
+but the same root cause):
+
+- A group `id` containing `-` (e.g. `X-y`) collides with group `X`'s track `y`
+  at `data['X-y']`.
+- A track literally named `foo__unfiltered` collides its primary key with track
+  `foo`'s `__unfiltered` filter baseline.
+
+## Impact and preconditions
+
+Exploitation requires the `viewerConfig` / `config-src` to be **attacker-controlled**.
+In the intended deployment the config is authored by the integrating application,
+so this is a hardening item, not an active vulnerability. It matters only for an
+integrator that assembles a `<protvista-uniprot>` config from untrusted input.
+
+**Severity: Low (defense-in-depth).** No global prototype pollution; no data
+exfiltration; no code execution.
+
+## Recommended remediation
+
+Any (or all) of the following close the class:
+
+1. **Null-prototype loader map** — immune to the `__proto__` setter:
+   ```ts
+   const data: Record<string, unknown> = Object.create(null);
+   ```
+   Cheapest fix. Confirm downstream `Object.entries(this.data)` / object spreads
+   still behave (they do — those operate on own properties).
+2. **Schema id allowlist** — add a `pattern` to the group/track `id` schema in
+   `src/schema/schema.json`, e.g. `"pattern": "^[A-Za-z0-9_-]+$"`, rejecting
+   `__proto__`-style ids and separator characters at load time. Back it with a
+   normalize-time check if configs can bypass JSON-schema validation.
+3. **Reserve the separator / suffix** — validate that no id contains the `-`
+   composite separator or ends in `__unfiltered`, eliminating the collision
+   class; or key a structured `Map` with tuple keys instead of concatenated
+   strings.
+
+There is no existing key-sanitization helper today — `src/utils/security.ts`
+covers only HTML output (`escapeHtml`, `sanitizeUrl`). Options 1–2 above need no
+new helper; if a shared guard emerges, `src/utils/security.ts` is its natural
+home.
+
+## Disclosure
+
+The repository's [`SECURITY.md`](../SECURITY.md) asks that **exploitable
+vulnerabilities** be reported privately via GitHub Private Vulnerability
+Reporting rather than public issues/PRs. This item is documented publicly here
+because it is a **low-severity hardening / defense-in-depth** concern that is not
+exploitable under the intended trust model (it requires an already-untrusted
+config and yields only local map-integrity effects). If a future change makes
+config input untrusted by design — or introduces a deep, attacker-keyed merge —
+re-evaluate this against the private-reporting policy before publishing further
+detail.
+
+## Provenance
+
+- Surfaced during the security review of the `transformedVariants` →
+  `__unfiltered` filter-baseline refactor (resolves
+  [`architecture-audit.md` B3 / #156](./architecture-audit.md); the A11 entry
+  describes the original `transformedVariants` assumption).
+- **Pre-existing** — the bare-id group-aggregate write and the unconstrained
+  schema ids predate that refactor and are unaffected by it.

--- a/src/__spec__/__snapshots__/load-data-baseline.spec.ts.snap
+++ b/src/__spec__/__snapshots__/load-data-baseline.spec.ts.snap
@@ -4508,6 +4508,152 @@ exports[`loadProtvistaData baseline (schema-driven default config) > produces a 
         "type": "unique",
       },
     ],
+    "VARIATION-variation__unfiltered": [
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "ACT_SITE",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "BINDING",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "CA_BIND",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "CARBOHYD",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "CHAIN",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "COMPBIAS",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "CONFLICT",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "CROSSLNK",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "DISULFID",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "DNA_BIND",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "DOMAIN",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "INIT_MET",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "INTRAMEM",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "LIPID",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "METAL",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "MOD_RES",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "MOD_RES_LS",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "MOTIF",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "MUTAGEN",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "NON_CONS",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "NON_STD",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "NON_TER",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "NP_BIND",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "PEPTIDE",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "PROPEP",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "REGION",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "REPEAT",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "SIGNAL",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "SITE",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "TOPO_DOM",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "TRANSIT",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "TRANSMEM",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "UNSURE",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "ZN_FING",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "non_unique",
+      },
+      {
+        "_adapter": "uniprot-variation-json",
+        "type": "unique",
+      },
+    ],
     "VARIATION-variation_graph": [
       {
         "_adapter": "uniprot-variation-counts-json",
@@ -4796,6 +4942,7 @@ exports[`loadProtvistaData baseline (schema-driven default config) > returns an 
   "MUTAGENESIS",
   "VARIATION-variation_graph",
   "VARIATION-variation",
+  "VARIATION-variation__unfiltered",
   "VARIATION",
   "RNA_EDITING-rna_editing_graph",
   "RNA_EDITING-RNA Editing",

--- a/src/__spec__/filter-change.spec.ts
+++ b/src/__spec__/filter-change.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * Component-level coverage for the variant filter's change handler.
+ *
+ * Guards the de-hardcoding of the filter baseline: `handleFilterClick`
+ * used to read a private `transformedVariants` field and write back to
+ * the literal key `'VARIATION-variation'`. It now reads a pristine
+ * baseline from `${trackKey}${UNFILTERED_SUFFIX}` (written by the loader
+ * for any `filterUI: 'nightingale-filter'` track) and writes the
+ * filtered result to `trackKey` — with `trackKey` threaded in from the
+ * `@change` binding rather than hardcoded.
+ *
+ * The test deliberately drives a track whose id is NOT `variation`
+ * (`RNA_EDITING-user_defined_variants`) to prove no id string is baked
+ * into the handler. It also asserts the `__unfiltered` baseline is left
+ * untouched, so repeated filtering can never compound.
+ *
+ * As with the other component-level specs, nightingale packages are
+ * stubbed (via `src/__spec__/nightingale-mocks.ts`, wired through
+ * `setupFiles`) and the element is never mounted — we set state directly
+ * and call the handler.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import '../protvista-uniprot';
+import { UNFILTERED_SUFFIX } from '../load-data';
+
+type FilterDef = {
+  name: string;
+  type: { name: string };
+  filterPredicate: (variant: Record<string, unknown>) => boolean;
+};
+
+type ProtvistaUniprotLike = HTMLElement & {
+  data: Record<string, any>;
+  handleFilterClick(e: CustomEvent, trackKey: string): void;
+  _loadDataInComponents(): Promise<void>;
+};
+
+const TRACK_KEY = 'RNA_EDITING-user_defined_variants';
+const BASELINE_KEY = `${TRACK_KEY}${UNFILTERED_SUFFIX}`;
+const SEQUENCE = 'MKTAYIAK';
+
+/** Three variants spanning two consequence types × two provenances. */
+function baselineVariants() {
+  return [
+    { protvistaFeatureId: 'v1', consequenceType: 'missense', sourceType: 'large_scale_study' },
+    { protvistaFeatureId: 'v2', consequenceType: 'stop_gained', sourceType: 'uniprot' },
+    { protvistaFeatureId: 'v3', consequenceType: 'missense', sourceType: 'uniprot' },
+  ];
+}
+
+/** Facet defs shaped like the entries `groupByGroup`/`getFilter` expect. */
+const FILTERS: FilterDef[] = [
+  {
+    name: 'consequence:missense',
+    type: { name: 'consequence' },
+    filterPredicate: (v) => v.consequenceType === 'missense',
+  },
+  {
+    name: 'consequence:stop_gained',
+    type: { name: 'consequence' },
+    filterPredicate: (v) => v.consequenceType === 'stop_gained',
+  },
+  {
+    name: 'provenance:uniprot',
+    type: { name: 'provenance' },
+    filterPredicate: (v) => v.sourceType === 'uniprot',
+  },
+  {
+    name: 'provenance:large_scale_study',
+    type: { name: 'provenance' },
+    filterPredicate: (v) => v.sourceType === 'large_scale_study',
+  },
+];
+
+function buildElement(): ProtvistaUniprotLike {
+  const el = document.createElement(
+    'protvista-uniprot'
+  ) as unknown as ProtvistaUniprotLike;
+  // Mirror the loader exactly: it writes the SAME object reference to the
+  // live slot and the `__unfiltered` baseline. Sharing the reference here
+  // (rather than two independent copies) means a regression that mutated
+  // the baseline in place would corrupt the live slot's array too, and
+  // the "baseline stays pristine" assertions below would catch it.
+  const payload = { sequence: SEQUENCE, variants: baselineVariants() };
+  el.data = {
+    [TRACK_KEY]: payload,
+    [BASELINE_KEY]: payload,
+  };
+  // `_loadDataInComponents` awaits `frame()` and pokes the DOM; the
+  // element is never mounted, so stub it out to isolate the data write.
+  el._loadDataInComponents = vi.fn(async () => undefined);
+  return el;
+}
+
+/** A `nightingale-filter` `change` event with the given selection. */
+function filterEvent(selected: string[]): CustomEvent {
+  return {
+    target: { filters: FILTERS },
+    detail: { value: selected },
+  } as unknown as CustomEvent;
+}
+
+describe('<protvista-uniprot>.handleFilterClick() — de-hardcoded filter baseline', () => {
+  it('filters a non-"variation" track against its pristine baseline', () => {
+    const el = buildElement();
+
+    // missense ∧ uniprot → only v3 survives.
+    el.handleFilterClick(
+      filterEvent(['consequence:missense', 'provenance:uniprot']),
+      TRACK_KEY
+    );
+
+    const live = el.data[TRACK_KEY] as {
+      sequence: string;
+      variants: Array<{ protvistaFeatureId: string }>;
+    };
+    expect(live.variants.map((v) => v.protvistaFeatureId)).toEqual(['v3']);
+    // Non-`variants` fields are carried through from the baseline spread.
+    expect(live.sequence).toBe(SEQUENCE);
+
+    // No `variation`/`VARIATION-variation` key was ever touched — the id
+    // hardcode is gone.
+    expect(el.data['VARIATION-variation']).toBeUndefined();
+
+    // The push-to-components hook fired exactly once.
+    expect(el._loadDataInComponents).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the __unfiltered baseline pristine so repeated filtering does not compound', () => {
+    const el = buildElement();
+
+    // First interaction: narrow to a single stop_gained/uniprot variant.
+    el.handleFilterClick(
+      filterEvent(['consequence:stop_gained', 'provenance:uniprot']),
+      TRACK_KEY
+    );
+    expect(
+      (el.data[TRACK_KEY] as { variants: unknown[] }).variants
+    ).toHaveLength(1);
+    // Baseline untouched by the first filter.
+    expect(
+      (el.data[BASELINE_KEY] as { variants: unknown[] }).variants
+    ).toHaveLength(3);
+
+    // Second interaction against the FULL baseline (not the 1-item
+    // result): missense ∧ uniprot → v3. If the handler had re-read the
+    // already-filtered live slot this would collapse to empty.
+    el.handleFilterClick(
+      filterEvent(['consequence:missense', 'provenance:uniprot']),
+      TRACK_KEY
+    );
+    expect(
+      (el.data[TRACK_KEY] as {
+        variants: Array<{ protvistaFeatureId: string }>;
+      }).variants.map((v) => v.protvistaFeatureId)
+    ).toEqual(['v3']);
+    expect(
+      (el.data[BASELINE_KEY] as { variants: unknown[] }).variants
+    ).toHaveLength(3);
+  });
+});

--- a/src/__spec__/load-data-baseline.spec.ts
+++ b/src/__spec__/load-data-baseline.spec.ts
@@ -52,7 +52,11 @@ import { dirname, resolve } from 'node:path';
 
 import { loadConfig } from '../schema/load';
 import type { NormalizedConfig } from '../schema/normalize';
-import { loadProtvistaData, type AdapterMap } from '../load-data';
+import {
+  loadProtvistaData,
+  UNFILTERED_SUFFIX,
+  type AdapterMap,
+} from '../load-data';
 
 const REFERENCE_ACCESSION = 'P05067';
 
@@ -284,6 +288,29 @@ describe('loadProtvistaData baseline (schema-driven default config)', () => {
     ] as ReturnType<typeof vi.fn>;
     expect(variationAdapter).not.toHaveBeenCalled();
     expect(result.data).not.toHaveProperty('VARIATION-variation');
+  });
+
+  it('mirrors a filterUI track under an __unfiltered baseline key', async () => {
+    // The default config's variation track sets
+    // `filterUI: nightingale-filter`, so the loader mirrors its adapted
+    // payload under `${trackKey}${UNFILTERED_SUFFIX}` — the pristine
+    // baseline the component's filter handler re-filters against without
+    // compounding. The opt-in is `filterUI`, NOT a hardcoded track id.
+    const result = await loadProtvistaData(
+      REFERENCE_ACCESSION,
+      config,
+      cannedFetch,
+      mockAdapters
+    );
+    const baselineKey = `VARIATION-variation${UNFILTERED_SUFFIX}`;
+    // Same reference as the live slot at load time.
+    expect(result.data[baselineKey]).toBe(result.data['VARIATION-variation']);
+    // ...and it is the ONLY baseline: tracks without `filterUI` get no
+    // `__unfiltered` copy, proving no id is special-cased.
+    const unfilteredKeys = Object.keys(result.data).filter((k) =>
+      k.endsWith(UNFILTERED_SUFFIX)
+    );
+    expect(unfilteredKeys).toEqual([baselineKey]);
   });
 
   it('rewrites InterPro representative fragments with the expected synthetic type', async () => {

--- a/src/load-data.ts
+++ b/src/load-data.ts
@@ -23,13 +23,16 @@
  *      `.flat()` for most components, or `groupData[0]` for
  *      linegraph / colored-sequence groups.
  *
- * Intentionally kept side-effect-free: no `this`, no DOM, no
- * `transformedVariants`. That legacy side-effect is preserved in the
- * component's wrapper by reading `data['VARIATION-variation']` after the
- * call.
+ * Intentionally kept side-effect-free: no `this`, no DOM. Tracks that
+ * opt into a filter UI (`filterUI: 'nightingale-filter'`) get their
+ * adapted payload mirrored under a second key,
+ * `${groupId}-${trackId}${UNFILTERED_SUFFIX}`, so the component's filter
+ * handler has a pristine baseline to re-filter against without a
+ * separate class field. Consumers reading `data` directly must treat
+ * `__unfiltered` keys as inert baselines, not live renderer payload.
  */
 
-import type { NormalizedConfig } from './schema/normalize';
+import type { NormalizedConfig, NormalizedTrack } from './schema/normalize';
 import type { TransformedInterPro } from './adapters/types/interpro';
 import { resolveTooltip } from './tooltips/resolve';
 import { tooltipDefaults } from './tooltips/defaults';
@@ -60,11 +63,28 @@ type FetchOne = (url: string) => Promise<unknown>;
  */
 export type CustomTrackData = Record<string, unknown>;
 
+/**
+ * Sentinel suffix for the pristine, unfiltered baseline copy of a
+ * filterable track's payload. For a track keyed `${groupId}-${trackId}`
+ * whose config sets `filterUI: 'nightingale-filter'`, the loader mirrors
+ * the adapted payload at `${groupId}-${trackId}${UNFILTERED_SUFFIX}`. The
+ * component's filter handler reads the baseline from this key and writes
+ * the filtered result back to the primary key, so successive filter
+ * interactions never compound. Keys carrying this suffix are inert
+ * baselines — not live renderer payload.
+ */
+export const UNFILTERED_SUFFIX = '__unfiltered';
+
 type LoadResult = {
   /** Keyed by the *template* URL (pre-substitution), matching the legacy
    *  `this.rawData` shape the renderer reads. */
   rawData: Record<string, unknown>;
-  /** Keyed by `${groupId}-${trackId}` and `${groupId}`. */
+  /**
+   * Keyed by `${groupId}-${trackId}` and `${groupId}`. Tracks with
+   * `filterUI: 'nightingale-filter'` additionally get a pristine baseline
+   * copy at `${groupId}-${trackId}${UNFILTERED_SUFFIX}` for the filter
+   * handler to read from.
+   */
   data: Record<string, unknown>;
   /** True iff any raw response has `features.length > 0`. Mirrors the
    *  legacy `this.hasData` gate for rendering empty-state markup. */
@@ -204,6 +224,21 @@ export async function loadProtvistaData(
 
   const data: Record<string, unknown> = {};
 
+  // Write a track's adapted payload to its primary key, plus a pristine
+  // `__unfiltered` baseline when the track opts into a filter UI. Both
+  // assignment sites (`from: custom` and url/inline) route through here
+  // so the baseline opt-in rule lives in exactly one place.
+  const assignTrackData = (
+    key: string,
+    payload: unknown,
+    track: NormalizedTrack
+  ) => {
+    data[key] = payload;
+    if (track.filterUI === 'nightingale-filter') {
+      data[`${key}${UNFILTERED_SUFFIX}`] = payload;
+    }
+  };
+
   for (const group of config.groups) {
     const groupId = group.id;
     const groupData = await Promise.all(
@@ -249,7 +284,7 @@ export async function loadProtvistaData(
             trackId,
             kind: kind ?? '',
           });
-          data[trackKey] = annotated;
+          assignTrackData(trackKey, annotated, track);
           return annotated;
         }
 
@@ -317,8 +352,8 @@ export async function loadProtvistaData(
           kind: kind ?? '',
         });
 
-        // 4. Assign track data
-        data[`${groupId}-${trackId}`] = annotated;
+        // 4. Assign track data (+ a pristine baseline for filter tracks)
+        assignTrackData(trackKey, annotated, track);
         return annotated;
       })
     );

--- a/src/protvista-uniprot.ts
+++ b/src/protvista-uniprot.ts
@@ -36,7 +36,11 @@ import alphaMissenseHeatmapAdapter from './adapters/alphamissense-heatmap-adapte
 import ProtvistaUniprotStructure from './protvista-uniprot-structure';
 
 import { loadComponent } from './utils';
-import { loadProtvistaData, type CustomTrackData } from './load-data';
+import {
+  loadProtvistaData,
+  UNFILTERED_SUFFIX,
+  type CustomTrackData,
+} from './load-data';
 import {
   installClickTooltip,
   type TooltipController,
@@ -129,10 +133,6 @@ class ProtvistaUniprot extends LitElement {
   private suspend?: boolean;
   private accession?: string;
   private sequence?: string;
-  private transformedVariants?: {
-    sequence: string;
-    variants: TransformedVariant[];
-  };
   /**
    * Fully-resolved config consumed by the renderer and
    * `loadProtvistaData()`. Populated in `_init()` by running the
@@ -199,7 +199,6 @@ class ProtvistaUniprot extends LitElement {
     this.data = {};
     this.rawData = {};
     this.displayCoordinates = {};
-    this.transformedVariants = { sequence: '', variants: [] };
     this.addStyles();
   }
 
@@ -318,25 +317,11 @@ class ProtvistaUniprot extends LitElement {
     // tracked properties, so we keep the call).
     this.data = { ...this.data, ...data };
 
-    // Preserve the pre-extraction side-effect: every track with
-    // `id === 'variation'` feeds `this.transformedVariants`. In the
-    // current config only VARIATION-variation exists, but the
-    // legacy code matched by track id alone — so mirror that exactly.
-    // TODO(#variation-hardcoded): lift the id-based match out of the
-    // component and into a track-level role/flag so arbitrary
-    // consumer configs can opt into the variation-filter surface.
-    for (const group of this.config.groups) {
-      for (const track of group.tracks) {
-        if (track.id === 'variation') {
-          const key = `${group.id}-${track.id}`;
-          if (key in data) {
-            this.transformedVariants = data[
-              key
-            ] as typeof this.transformedVariants;
-          }
-        }
-      }
-    }
+    // The variation filter's pristine baseline now rides along in
+    // `data` under `${groupId}-${trackId}${UNFILTERED_SUFFIX}` for any
+    // track that opts into `filterUI: 'nightingale-filter'` — written by
+    // the loader, consumed by `handleFilterClick`. No id-based copy step
+    // is needed here anymore.
 
     // Clear the stored controller if it's still us — if a newer call
     // already overwrote it, leaving ours stale would defeat
@@ -377,6 +362,10 @@ class ProtvistaUniprot extends LitElement {
   async _loadDataInComponents() {
     await frame();
     Object.entries(this.data).forEach(([id, data]) => {
+      // `__unfiltered` baselines are inert filter state, not renderable
+      // track/group payloads — skip them so this walk's "every key maps
+      // to a track or group" invariant holds.
+      if (id.endsWith(UNFILTERED_SUFFIX)) return;
       const element = this.findById<NightingaleTrackCanvas>(
         `${CSS_PREFIX}-track-${id}`
       );
@@ -1081,47 +1070,62 @@ class ProtvistaUniprot extends LitElement {
     return filters?.filter((f) => f.name === filterName)?.[0];
   }
 
-  // TODO(#variation-filter-hardcoded): this filter callback is wired
-  // exclusively for the variation track — it reads `consequence` and
-  // `provenance` facets out of `filterConfig` and writes back into
-  // `VARIATION-variation`. A non-variation track with its own filter UI
-  // would have to route around this handler. Moving the filter glue
-  // into `filter-config.ts` (or onto the track spec itself) would
-  // decouple the component from a single hardcoded kind.
-  handleFilterClick(e: CustomEvent) {
+  // The write target is no longer hardcoded: `trackKey` is threaded in
+  // from `getFilterComponent` (via the `@change` binding), and the
+  // pristine baseline is read from the loader-written
+  // `${trackKey}${UNFILTERED_SUFFIX}` slot — so any track that opts into
+  // `filterUI: 'nightingale-filter'` gets the same behaviour regardless
+  // of its id.
+  //
+  // TODO(#variation-filter-hardcoded): two things are still
+  // variation-specific — (1) the `consequence` / `provenance` facet set
+  // this handler reads, and (2) the `{ sequence, variants }` bundle
+  // shape it filters. Non-bundle payloads are skipped by the guard below
+  // rather than filtered. Moving the facet definitions plus a
+  // shape-agnostic predicate onto the track spec (or into
+  // `filter-config.ts`) would let arbitrary filterable tracks opt in.
+  handleFilterClick(e: CustomEvent, trackKey: string) {
     const target = e.target as Element as NightingaleFilter;
     const consequenceFilters = this.groupByGroup(target.filters, 'consequence');
     const provenanceFilters = this.groupByGroup(target.filters, 'provenance');
 
     const selectedFilters = e.detail?.value;
+    if (!selectedFilters) return;
 
-    if (selectedFilters) {
-      const selectedConsequenceFilters = selectedFilters
-        .map((f) => this.getFilter(consequenceFilters, f))
-        .filter(Boolean);
-      const selectedProvenanceFilters = selectedFilters
-        .map((f) => this.getFilter(provenanceFilters, f))
-        .filter(Boolean);
+    const baseline = this.data[`${trackKey}${UNFILTERED_SUFFIX}`] as
+      | { sequence: string; variants: TransformedVariant[] }
+      | undefined;
+    // `filterUI` is a generic opt-in, so guard against a baseline that is
+    // absent (filter fired before the loader ran) or not a variant
+    // bundle (e.g. a plain feature array) — either would be silently
+    // corrupted by the object-spread write below.
+    if (!baseline || !Array.isArray(baseline.variants)) return;
 
-      const filteredVariants = this.transformedVariants?.variants
-        ?.filter((variant) =>
-          selectedConsequenceFilters.some((filter) =>
-            filter.filterPredicate(variant)
-          )
+    const selectedConsequenceFilters = selectedFilters
+      .map((f) => this.getFilter(consequenceFilters, f))
+      .filter(Boolean);
+    const selectedProvenanceFilters = selectedFilters
+      .map((f) => this.getFilter(provenanceFilters, f))
+      .filter(Boolean);
+
+    const filteredVariants = baseline.variants
+      .filter((variant) =>
+        selectedConsequenceFilters.some((filter) =>
+          filter.filterPredicate(variant)
         )
-        .filter((variant) =>
-          selectedProvenanceFilters.some((filter) =>
-            filter.filterPredicate(variant)
-          )
-        );
+      )
+      .filter((variant) =>
+        selectedProvenanceFilters.some((filter) =>
+          filter.filterPredicate(variant)
+        )
+      );
 
-      this.data['VARIATION-variation'] = {
-        ...this.data['VARIATION-variation'],
-        variants: filteredVariants,
-      };
+    this.data[trackKey] = {
+      ...baseline,
+      variants: filteredVariants,
+    };
 
-      this._loadDataInComponents();
-    }
+    this._loadDataInComponents();
   }
 
   getGroupTypesAsString(tracks: NormalizedTrack[]) {
@@ -1133,7 +1137,7 @@ class ProtvistaUniprot extends LitElement {
       <nightingale-filter
         style="minWidth: 20%"
         for="${CSS_PREFIX}-track-${forId}"
-        @change="${this.handleFilterClick}"
+        @change="${(e: CustomEvent) => this.handleFilterClick(e, forId)}"
       ></nightingale-filter>
     `;
   }


### PR DESCRIPTION
## Purpose

Addresses https://github.com/ebi-webcomponents/protvista/issues/156

De-hardcode the variant filter so it works on any track that opts into the filter UI, instead of requiring a track whose id is literally `variation`.

## Approach

Removed the `transformedVariants` field and the `track.id === 'variation'` post-load copy loop. The data loader now writes a pristine `__unfiltered` baseline (keyed off `filterUI: 'nightingale-filter'`) alongside each filterable track's data; the change handler reads that baseline and writes the filtered result back under the track's own key, threaded in from the filter binding.

## Testing

* New `filter-change.spec.ts`: drives the filter against a **non-`variation`** track id, asserting the filtered write and that the baseline stays pristine across repeated filtering (shares one object ref, matching the loader).
* Added a `load-data-baseline.spec.ts` case asserting the `__unfiltered` key is produced only for `filterUI` tracks; updated the loader snapshot accordingly.

## Visual changes

None — behaviour is unchanged for the shipped config.

## Checklist

- [x] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved *(2 pre-existing `render-target.spec.ts` failures are environmental — they fail on `main` in this sandbox, unrelated to this change)*
- [x] If needed, the changes have been previewed by all interested parties.