### PR TITLE
Modernise styling with CSS custom-property tokens and datatable ::part.

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,170 @@
+# Theming ProtVista
+
+`<protvista-uniprot>` exposes a documented styling API built on two
+native web standards, so you can match the viewer to your application
+with **plain CSS and no JavaScript**:
+
+- **CSS custom properties** (`--protvista-*` design tokens) for colours,
+  sizes and other themable values. This is the primary surface.
+- **`::part`** for targeting structural elements of the shadow-DOM
+  datatable (rows, cells, header, filter controls).
+
+Overriding these is the supported way to customise the interface.
+Internal class names (the hash-prefixed `.pv-*` classes) are **not** a
+public API and may change between releases — theme through the tokens
+and parts below instead.
+
+> This document is licensed CC BY 4.0, like the rest of the ProtVista
+> documentation.
+
+## Why two mechanisms?
+
+The main viewer and the structure panel render in the **light DOM**
+(required by the embedded Mol\* structure viewer), so their themable
+values are exposed as custom properties, which you set on the element or
+any ancestor. The datatable renders in a **shadow root**, so in addition
+to custom properties (which pierce the boundary through inheritance) it
+also exposes `::part` hooks for structural styling that a custom
+property alone can't express.
+
+## Quick start
+
+```css
+/* Theme every ProtVista instance on the page. */
+:root {
+  --protvista-color-accent: #7b2d8e;
+  --protvista-group-label-bg: #efe6f5;
+  --protvista-radius: 8px;
+}
+
+/* Theme one instance. */
+protvista-uniprot#my-viewer {
+  --protvista-track-label-bg: #f2f2f2;
+}
+
+/* Reach into the datatable's shadow DOM with ::part. */
+protvista-uniprot-datatable::part(row-active) {
+  outline: 2px solid #7b2d8e;
+}
+```
+
+Because tokens are ordinary custom properties, they are also settable at
+runtime — `element.style.setProperty('--protvista-color-accent', …)` —
+which is how an interactive controls panel can drive live theming.
+
+## Design tokens
+
+Every token has a sensible default (shown below), so a viewer with no
+custom CSS renders exactly as it always has. Component tokens whose
+default is written as `var(--protvista-…)` inherit from the global tier,
+so overriding one global token (e.g. `--protvista-color-accent`)
+cascades everywhere it is used.
+
+### Global
+
+| Token | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `--protvista-font-family` | font | `inherit` | Base font family for viewer chrome. |
+| `--protvista-font-size` | length | `0.8rem` | Base font size for viewer chrome. |
+| `--protvista-color-accent` | color | `#0053d6` | Accent — focus rings, active-row marker, primary UI. |
+| `--protvista-color-text` | color | `#222222` | Default body text colour. |
+| `--protvista-color-text-muted` | color | `#4a5056` | Muted/secondary text (tooltip labels, captions). |
+| `--protvista-color-surface` | color | `#ffffff` | Surface/background for popovers and panels. |
+| `--protvista-color-border` | color | `#c5c8cc` | Default border for popovers and panels. |
+| `--protvista-color-disabled` | color | `#808080` | Disabled controls. |
+| `--protvista-radius` | length | `4px` | Corner radius for popovers and controls. |
+| `--protvista-shadow-popover` | shadow | `0 4px 12px rgb(0 0 0 / 0.15)` | Drop shadow for floating popovers. |
+
+### Viewer (labels, navigation, empty states)
+
+| Token | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `--protvista-track-content-width` | length | `80vw` | Width of the track-content (visualisation) column. |
+| `--protvista-label-width` | length | `20vw` | Width of the label column (group/track/nav labels, credits). |
+| `--protvista-group-label-bg` | color | `#b2f5ff` | Background of collapsible group labels. |
+| `--protvista-track-label-bg` | color | `#d9faff` | Background of individual track labels. |
+| `--protvista-track-border-color` | color | `var(--protvista-track-label-bg)` | Top border between stacked track rows. |
+| `--protvista-caret-color` | color | `#333333` | Group-label expand/collapse caret. |
+| `--protvista-nav-handle-fill` | color | `darkgrey` | Fill of the navigation zoom handles. |
+| `--protvista-nav-handle-stroke` | color | `black` | Stroke of the navigation zoom handles. |
+| `--protvista-no-results-bg` | color | `#e4e8eb` | Background of the "no results" empty state. |
+
+### Tooltip
+
+| Token | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `--protvista-tooltip-bg` | color | `var(--protvista-color-surface)` | Tooltip background. |
+| `--protvista-tooltip-color` | color | `var(--protvista-color-text)` | Tooltip text colour. |
+| `--protvista-tooltip-border` | color | `var(--protvista-color-border)` | Tooltip border and arrow colour. |
+| `--protvista-tooltip-max-width` | length | `320px` | Maximum tooltip width before text wraps. |
+
+### Datatable
+
+| Token | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `--protvista-datatable-accent` | color | `var(--protvista-color-accent)` | Accent — focus outline, active-row marker. |
+| `--protvista-datatable-text-head` | color | `#1a1a1a` | Header-cell text colour. |
+| `--protvista-datatable-text-body` | color | `#2c2c2c` | Body-cell text colour. |
+| `--protvista-datatable-text-muted` | color | `#444444` | Muted text (e.g. the no-results message). |
+| `--protvista-datatable-text-input` | color | `#333333` | Filter `<select>` text colour. |
+| `--protvista-datatable-bg-base` | color | `var(--protvista-color-surface)` | Datatable base background. |
+| `--protvista-datatable-bg-header` | color | `#f8f8f8` | Sticky header-row background. |
+| `--protvista-datatable-bg-hover` | color | `#f1f7ff` | Row hover/focus background. |
+| `--protvista-datatable-bg-active` | color | `#e6f3ff` | Selected/active-row background. |
+| `--protvista-datatable-border` | color | `#e0e0e0` | Cell and container borders. |
+| `--protvista-datatable-border-input` | color | `#767676` | Filter `<select>` border. |
+| `--protvista-datatable-shadow-header` | color | `#cccccc` | Under-shadow of the sticky header row. |
+| `--protvista-datatable-max-height` | length | `400px` | Max height of the scroll container before it scrolls. |
+
+> **Migrating from `--protvista-dt-*`:** the datatable tokens were
+> previously named `--protvista-dt-*`. Those names still work as aliases
+> for one major cycle — an existing `--protvista-dt-primary` override, for
+> example, is honoured by `--protvista-datatable-accent` — but new code
+> should use the `--protvista-datatable-*` names.
+
+## Datatable `::part`
+
+The datatable (`<protvista-uniprot-datatable>`, used inside the
+structure panel) exposes these parts:
+
+| Part | Element |
+| --- | --- |
+| `scroll-container` | The scrolling wrapper around the table. |
+| `table` | The `<table>` element. |
+| `header` | The `<thead>` header section. |
+| `header-cell` | Each header `<th>`. |
+| `filter-select` | Each column filter `<select>`. |
+| `row` | Every body row. |
+| `row-active` | The selected row (in addition to `row`). |
+| `cell` | Every body `<td>`. |
+| `no-results` | The empty-state cell shown when a filter matches nothing. |
+
+```css
+protvista-uniprot-datatable::part(header) {
+  background: #1a1a2e;
+  color: #fff;
+}
+protvista-uniprot-datatable::part(row):hover {
+  background: #fff7e6;
+}
+```
+
+## What is *not* themable here
+
+- **Data-domain colours** — the AlphaFold pLDDT and AlphaMissense
+  pathogenicity ramps, and variant/PTM colours — are semantic data
+  encodings, not interface chrome. They are themed through the viewer
+  configuration (`registerTheme()` / rendering presets), not these
+  tokens.
+- **Nightingale track internals** — the track canvases are rendered by
+  the upstream `@nightingale-elements/*` components; only the properties
+  those components choose to expose can be set from here.
+
+## On the roadmap
+
+- **Dark mode** — a `prefers-color-scheme` default token set. The token
+  layer above is the substrate; the palette itself is planned follow-on.
+- **Colour-blind-friendly palettes** — part of the viewer's WCAG
+  accessibility work; likewise a token-swap on top of this layer.
+- **No-code styling panel** — the interactive playground will let
+  non-developers adjust these tokens with live preview.

--- a/specs/styling-architecture.md
+++ b/specs/styling-architecture.md
@@ -1,0 +1,372 @@
+# Styling architecture — modernisation design
+
+Design for a single, standards-based styling architecture for
+`protvista-uniprot` built on **CSS custom properties** (design tokens)
+and **`::part`**, replacing three divergent ad-hoc styling mechanisms
+with one documented theming contract that library consumers can
+customise without forking.
+
+**Status: the Q2 core slice is implemented** (token registry, all three
+components migrated, datatable `::part`, inline styles removed, unified
+injection, `docs/theming.md`). Dark mode, colour-blind palettes, and a
+no-code styling panel are deliberately deferred — see
+[Roadmap alignment & Q2 delivery](#roadmap-alignment--q2-delivery).
+
+It is scoped to the *chrome/UI* styling of the viewer (labels,
+tooltips, tables, legends, loaders, empty states) and deliberately
+excludes data-domain colour ramps (pLDDT, AlphaMissense, disease
+variants), which already have their own theming path — see
+[Scope boundaries](#scope-boundaries).
+
+## Audience
+
+This surface serves **developer-integrators** — people embedding
+`<protvista-uniprot>` in an application who want it to match their design
+system. That is exactly the "customise the interface" of ROADMAP.md
+line 59 ("allow *library users* to customise"). It is deliberately
+*not* the same as two adjacent, distinct pieces of work:
+
+- the **no-code track-configuration UI** (reorder / show / hide tracks)
+  for non-technical end-users (ROADMAP line 60), and
+- the **non-coding bench scientists** the Starter Kit targets.
+
+Theming here is a write-CSS surface *by design*: overriding a token or a
+`::part` rule is a developer action. The registry (`src/styles/tokens.ts`)
+is nonetheless the **substrate** a future no-code styling panel can drive
+— it can enumerate the typed tokens and write overrides via
+`host.style.setProperty(...)` — so building that panel does not require
+re-plumbing anything here.
+
+## Purpose
+
+Today a consumer who embeds `<protvista-uniprot>` cannot recolour a
+group label, restyle a tooltip, or match the datatable to their app's
+design system without overriding undocumented, explicitly-unstable
+internal class names. The three components style themselves three
+different ways, colours and spacing are hardcoded as literals in a
+dozen places, and the structure component scatters inline `style=`
+attributes that no consumer can reach and that fight a strict CSP.
+
+This is technical debt on two axes:
+
+- **Maintenance.** The same colour (`#0053d6`, `#d9faff`, …) is
+  restated across files; there is no single place to change the
+  viewer's look; three injection paths must each be understood and
+  kept working.
+- **Extensibility.** ProtVista's grant goal is to become a
+  *low-friction, embeddable* tool (see
+  [`specs/config-approach.md`](./config-approach.md)). A viewer an
+  external lab cannot make look like *their* viewer is a viewer they
+  will fork or abandon. Customisation is a first-class adopter need,
+  not a nice-to-have.
+
+The fix is a documented theming contract built from web-native
+primitives, so consumers customise the viewer with plain CSS and no
+JavaScript.
+
+## Current state
+
+Three components, three mechanisms — inventoried against the baseline
+tree so the removal target is concrete.
+
+| Component | Render root | Style mechanism | Customisation surface |
+| --- | --- | --- | --- |
+| `protvista-uniprot` (main) | **Light DOM** (`createRenderRoot() → this`, forced by Mol\*) | Lit `css` templates in `src/styles/{protvista,loader}-styles.ts`, `.toString()`-ed into one global `<style data-protvista-uniprot>` in `<head>` via `addStyles()`. Classes carry the `CSS_PREFIX` hash (`pv-cecb45`) and are tag-scoped under `protvista-uniprot`. | **None.** All colours hardcoded (`#b2f5ff`, `#d9faff`, `#333`, tooltip `#fff/#222/#c5c8cc`). No custom properties. Class names explicitly *not* part of the compat contract (audit §C). |
+| `protvista-uniprot-structure` | **Light DOM** (`createRenderRoot() → this`) | `get cssStyle()` `css` template injected as a global `<style id=…>` in `<head>`, **plus** inline `style="…"` attributes on legend swatches and icons with hardcoded `rgb()` / `#808080`. | **None.** Inline styles are unreachable and CSP-hostile. |
+| `protvista-uniprot-datatable` | **Shadow DOM** (`static styles`) | Real encapsulation. Already uses custom properties (`--protvista-dt-*` on `:host`) plus `--protvista-datatable-max-height`. | **Partial.** Custom properties pierce the shadow boundary so a consumer *can* override colours — but they are undocumented, inconsistently namespaced, and there are **no `part` attributes**, so structural elements (rows, header, cells, filter selects) can't be targeted. |
+
+Hardcoded UI colour/spacing literals to migrate live in
+`src/styles/protvista-styles.ts`, `src/styles/loader-styles.ts`, and
+`src/protvista-uniprot-structure.ts` (both the `cssStyle` block and the
+inline attributes). The datatable's `:host` block is already
+token-shaped and becomes the naming reference the other two adopt.
+
+## Design principles
+
+1. **Web-native, no framework.** Only CSS custom properties, `::part`,
+   `@media (prefers-color-scheme)`, and the cascade. No CSS-in-JS
+   theming runtime, no build-time preprocessor, no new dependency.
+2. **The customisation primitive follows the render root.** This is the
+   load-bearing constraint and the reason a naïve "just add `::part`
+   everywhere" plan fails:
+   - **Shadow DOM (datatable)** → expose internals with **`part`
+     attributes** so consumers write `protvista-uniprot-datatable::part(row)`,
+     *and* accept themable **custom properties** (they pierce the
+     boundary).
+   - **Light DOM (main, structure)** → `::part` does **not** apply
+     (there is no shadow boundary to cross). The stable, documented
+     surface is **CSS custom properties**. Internal class names remain
+     private (audit §C) and must *not* be promoted to public API; the
+     hash prefix stays as collision defence.
+3. **One token vocabulary, defaults included.** A single
+   `--protvista-*` namespace, defined once with fallback defaults at
+   the point of use (`var(--protvista-x, <default>)`), so the viewer
+   looks identical with zero consumer CSS and fully retheme-able with a
+   few declarations.
+4. **Semantic tokens, not raw values.** Consumers set intent
+   (`--protvista-color-accent`) not implementation
+   (`--protvista-group-label-bg: #b2f5ff` derives from the accent).
+   Two tiers: a small **global** set and per-component tokens that
+   default *from* the global set.
+5. **Defaults are a contract; internals are not.** The documented token
+   names and `part` names become part of the v-cycle compatibility
+   surface (audit §C). Everything else stays free to change.
+
+## Target architecture
+
+### 1. A design-token layer
+
+Introduce `src/styles/tokens.ts` exporting a single `css` block that
+defines defaults on the `protvista-uniprot` host (and re-declared on
+the datatable `:host` so shadow-encapsulated defaults still resolve).
+Proposed vocabulary (illustrative, finalise during implementation):
+
+```
+/* Global — the small set consumers reach for first */
+--protvista-font-family        (default: inherit)
+--protvista-font-size          (default: 0.8rem)
+--protvista-color-accent       (default: #0053d6)   /* datatable primary, focus rings */
+--protvista-color-text         (default: #222)
+--protvista-color-text-muted   (default: #4a5056)
+--protvista-color-surface      (default: #fff)
+--protvista-color-border       (default: #c5c8cc)
+--protvista-radius             (default: 4px)
+--protvista-shadow-popover     (default: 0 4px 12px rgb(0 0 0 / .15))
+--protvista-z-structure        (default: 40000)
+
+/* Component — default FROM the global set, override for fine control */
+--protvista-group-label-bg     (default: #b2f5ff)
+--protvista-track-label-bg     (default: #d9faff)
+--protvista-tooltip-bg         (default: var(--protvista-color-surface))
+--protvista-tooltip-border     (default: var(--protvista-color-border))
+--protvista-datatable-*        (rename/alias of today's --protvista-dt-*)
+```
+
+Every hardcoded literal in the three UI style sources is replaced with
+`var(--protvista-…, <current-literal-as-default>)`. The inline
+`style=` attributes in the structure component move into the `cssStyle`
+block as classed rules that read tokens (removing the CSP-hostile
+inline styles). Data-domain swatch colours that are genuinely data
+(the AF/AM legend fills) stay as values but are sourced from the same
+ramp definitions the tracks use, not restated — see scope.
+
+### 2. `::part` on shadow-DOM components
+
+Add `part` attributes to the datatable's rendered elements so consumers
+can target structure, not just colour:
+
+```
+part="scroll-container" | "table" | "header" | "header-cell"
+part="filter-select" | "row" | "row-active" | "cell" | "no-results"
+```
+
+Documented as the datatable's public styling API alongside its
+`--protvista-datatable-*` tokens. This is the template for any future
+shadow-DOM component. (The two light-DOM components get no `part`
+attributes — see principle 2.)
+
+### 3. Unify style injection
+
+Collapse the two global-`<style>`-into-`<head>` paths (main +
+structure) into one shared helper that (a) installs the token layer
+once, (b) is idempotent per stylesheet (extend the existing
+`data-protvista-uniprot` guard), and (c) keeps the datatable on
+`static styles` in its shadow root. Net result: one token source of
+truth, one injection code path for light-DOM chrome, standard shadow
+styling for the encapsulated component.
+
+### 4. Theming entry points (documented)
+
+Consumers override tokens at any level above the component:
+
+```css
+/* App-wide */
+:root { --protvista-color-accent: #7b2d8e; --protvista-radius: 8px; }
+
+/* One instance */
+protvista-uniprot#my-viewer { --protvista-group-label-bg: #eee; }
+
+/* Datatable structure via ::part */
+protvista-uniprot-datatable::part(row-active) { outline: 2px solid hotpink; }
+```
+
+Optional stretch: ship a `@media (prefers-color-scheme: dark)` default
+token set so the viewer is dark-mode-aware out of the box. Gated behind
+verifying legibility of Nightingale-owned track canvases (audit §C2:
+those are upstream-owned and out of our styling reach) — recommend
+scoping dark mode as a follow-on, not MVP.
+
+## Scope boundaries
+
+**In scope** — UI/chrome styling authored in this package: group &
+track labels, the collapse caret, nav/credits rows, the click-tooltip
+popover, the loader and no-results/empty states, the structure
+component's meta panel and legend layout, and the datatable.
+
+**Out of scope** — *data-domain* colours, which already have a theming
+mechanism and must not be conflated with UI tokens:
+
+- AlphaFold pLDDT and AlphaMissense ramps
+  (`src/renderer/render-helpers.ts`, `amColorScale`) — themable via the
+  config's `registerTheme()` path (audit §A7).
+- Variant/disease/PTM-tier colours (`src/filter-config.ts`,
+  `ptm-exchange-adapter.ts`) — semantic data encodings owned by the
+  adapter/filter layer.
+- Nightingale child components' own internal styling — upstream package
+  boundary (audit §C2). We can only set custom properties they choose
+  to expose; we do not restyle their shadow internals.
+
+Keeping these out prevents the token layer from ballooning into a
+data-visualisation theming system, which is a separate concern.
+
+## Roadmap alignment & Q2 delivery
+
+This work maps to **ROADMAP.md, Q2 (Months 4–6), line 59** —
+"Modernise the styling architecture, using native web standards like CSS
+`::part` and custom properties, to reduce technical debt and allow
+library users to customise the interface." It is a roadmap line, not a
+panel-scored grant deliverable (those are the functional beta, the
+webinar, and the playground beta), so it was scoped tightly to
+*reinforce* those items rather than compete with them near the 31 July
+Q2 boundary. It advances two grant themes directly: **reducing technical
+debt** (three ad-hoc mechanisms → one token layer) and providing the
+**substrate** for both the interactive playground and the WCAG
+colour-blind-palette accessibility commitment.
+
+**Shipped this quarter (additive, backward-compatible, defaults ==
+prior literals → zero visual change):**
+
+- `src/styles/tokens.ts` — the structured token registry.
+- All three components migrated to `var(--protvista-*)`; the structure
+  component's inline `style=` attributes removed.
+- `::part` on the datatable; `--protvista-dt-*` → `--protvista-datatable-*`
+  with back-compat aliases.
+- Unified light-DOM injection (`src/styles/inject.ts`).
+- `docs/theming.md` (CC BY 4.0), plus a `theming.spec.ts` guard.
+
+**Deferred (tracked as `next`-label issues, per the grant's
+scheduling-risk mitigation):**
+
+- **Dark mode** — a `prefers-color-scheme` default set. Depends on
+  Nightingale-owned track-canvas legibility we don't control (§C2); the
+  registry makes it a later token-swap.
+- **Colour-blind-friendly palettes** — part of the **Q3 WCAG
+  accessibility** deliverable (ROADMAP line 82). The token layer is the
+  hand-off point: shipping accessible palettes becomes a token-set swap
+  on top of this foundation, not a re-architecture.
+- **Live no-code styling panel** — belongs with the Q2 track-config-UI /
+  playground workstream; the registry is the ready substrate.
+
+The `docs/theming.md` reference is published under CC BY 4.0 (Q2/Q4
+documentation outputs); its typed token vocabulary also serves as the
+kind of clear, machine-readable boundary the grant argues aids
+AI-assisted maintenance.
+
+## Backwards compatibility
+
+- **New public surface.** The documented `--protvista-*` tokens and the
+  datatable `part` names become part of the compatibility contract for
+  the current major cycle (audit §C). Adding this surface is
+  non-breaking: with no consumer CSS the rendered output is
+  pixel-identical (defaults equal today's literals).
+- **Datatable token rename.** `--protvista-dt-*` →
+  `--protvista-datatable-*` for namespace consistency. Keep the old
+  names as `var()` aliases for one major cycle; announce via the `next`
+  label per the audit's mitigation policy.
+- **Internal class names stay private.** The `CSS_PREFIX` hash and
+  tag-scoping are retained; nothing here promotes a class name to
+  public API (audit §C explicitly excludes class names).
+- **Injected `<style>` marker changed.** Unifying injection replaced the
+  old `data-protvista-uniprot` marker attribute (and the structure
+  component's `id="protvista-styles"`) with keyed `data-protvista-style`
+  nodes. Like the class names, this marker is an internal implementation
+  detail, not part of the compatibility contract; there are no in-repo
+  consumers.
+- **Token defaults live on `:root`.** They are declared on
+  `:where(:root)` (specificity 0), not on the host tags, so that a
+  consumer's `:root { --protvista-…: … }` / ancestor / per-instance
+  override wins — a value declared directly on the host would shadow an
+  inherited override. See `installTokenDefaults`.
+- **Shared sheets are page-lifetime.** The install-once token/loader/
+  component `<style>` nodes back every instance and are never removed on
+  disconnect — removing one would strip styling from other live viewers.
+- **Snapshot tests.** In practice the snapshots did **not** churn:
+  `render-target.spec.ts` captures the main component's light DOM (whose
+  structure is unchanged — token migration alters CSS text, not markup),
+  and the datatable/structure are mocked there, so the new `part`
+  attributes don't appear. All unit tests pass unchanged; a new
+  `src/styles/__spec__/theming.spec.ts` guards the registry, the
+  light-DOM defaults, the datatable's `::part` surface, and drift between
+  the registry and both the datatable `:host` defaults and the docs.
+
+## Work breakdown
+
+1. **Token vocabulary.** Land `src/styles/tokens.ts` with the global +
+   component token defaults; wire it into the injection path. No visual
+   change yet (defaults == literals).
+2. **Main component.** Replace literals in `protvista-styles.ts` /
+   `loader-styles.ts` with `var()` references. Update snapshots.
+3. **Structure component.** Move inline `style=` attributes into
+   token-reading classed rules in `cssStyle`; replace literals.
+4. **Datatable.** Rename tokens (+ aliases), add `part` attributes,
+   confirm existing `:host` defaults resolve from the global tier.
+5. **Injection unification.** Single idempotent helper for the two
+   light-DOM paths.
+6. **Docs.** New `docs/theming.md` — token reference table, `::part`
+   list, copy-paste theming recipes; link from `README.md` and the
+   architecture audit (updating the B9-adjacent styling-debt note).
+7. **(Stretch) dark mode.** `prefers-color-scheme` default set, gated
+   on track-canvas legibility.
+
+## Testing & acceptance
+
+- **Visual parity.** With zero consumer CSS, snapshot and a manual
+  render (`yarn start`) show no visual change from baseline. This is
+  the primary safety check — defaults must equal today's literals.
+- **Customisation works.** A test fixture sets `--protvista-color-accent`
+  and a `::part(row-active)` rule and asserts the override takes
+  effect (unit assertion on computed style + a demo page in the
+  fixtures).
+- **No inline styles remain** in the structure component's template
+  (grep gate in CI or a unit assertion) — proves the CSP-hostile path
+  is gone.
+- **Single token source.** Grep gate: no raw UI colour hex literals
+  outside `tokens.ts` in the three UI style sources (data-domain files
+  excluded).
+- `yarn test` (lint + types + unit) green; snapshots updated with a
+  reviewed, intentional diff.
+
+## Acceptance criteria
+
+- One documented `--protvista-*` token layer with defaults, consumed by
+  all three components.
+- Datatable internals reachable via `::part`.
+- Structure component free of inline `style=` attributes.
+- `docs/theming.md` published with a token reference, part list, and
+  working recipes.
+- Byte-for-byte visual parity at defaults; overrides demonstrably work.
+- Backwards-compatible: no class-name promotion, datatable tokens
+  aliased.
+
+## Open questions
+
+1. **Token granularity.** How fine-grained should component tokens go —
+   every colour, or only the handful adopters actually ask to change?
+   Recommend starting from the global tier + the datatable set already
+   in use, and adding component tokens on demonstrated demand.
+2. **Dark mode in this cycle or next?** Recommend next — it depends on
+   Nightingale-owned canvas legibility we don't control (§C2).
+3. **`--protvista-dt-*` alias lifetime.** One major cycle is proposed;
+   confirm against the team's deprecation policy in the audit's
+   mitigation section.
+
+## Cross-references
+
+- [`docs/architecture-audit.md`](../docs/architecture-audit.md) — §A14
+  (global `<style>` scoping), §C (compatibility surface; class names
+  are *not* contract), §C2 (Nightingale styling is upstream-owned).
+- [`specs/config-approach.md`](./config-approach.md) — the
+  low-friction-embedding goal this serves.
+- `src/styles/` — the three UI style sources this consolidates.
+- `src/protvista-uniprot-datatable.ts` — the existing token/`:host`
+  pattern that becomes the naming reference.

--- a/src/protvista-uniprot-datatable.ts
+++ b/src/protvista-uniprot-datatable.ts
@@ -59,23 +59,42 @@ export class ProtvistaUniprotDatatable<
   private pendingFocusId?: string;
 
   static override styles = css`
+    /* Themable via CSS custom properties. Each --protvista-datatable-*
+       token defaults from the shared global tier (--protvista-*, which
+       inherits in from the host) and falls back to its historical
+       literal. The former --protvista-dt-* names are still honoured as
+       aliases for one major cycle, so existing overrides keep working.
+       Consumers can also target structure via ::part(...) — see the
+       part="…" attributes in render(). */
     :host {
       display: block;
       width: 100%;
-      font-family: inherit;
+      font-family: var(--protvista-font-family, inherit);
 
-      --protvista-dt-primary: #0053d6;
-      --protvista-dt-text-head: #1a1a1a;
-      --protvista-dt-text-body: #2c2c2c;
-      --protvista-dt-text-muted: #444444;
-      --protvista-dt-text-input: #333333;
-      --protvista-dt-bg-base: #ffffff;
-      --protvista-dt-bg-header: #f8f8f8;
-      --protvista-dt-bg-hover: #f1f7ff;
-      --protvista-dt-bg-active: #e6f3ff;
-      --protvista-dt-border: #e0e0e0;
-      --protvista-dt-border-input: #767676;
-      --protvista-dt-shadow-header: #cccccc;
+      --protvista-datatable-accent: var(
+        --protvista-dt-primary,
+        var(--protvista-color-accent, #0053d6)
+      );
+      --protvista-datatable-text-head: var(--protvista-dt-text-head, #1a1a1a);
+      --protvista-datatable-text-body: var(--protvista-dt-text-body, #2c2c2c);
+      --protvista-datatable-text-muted: var(--protvista-dt-text-muted, #444444);
+      --protvista-datatable-text-input: var(--protvista-dt-text-input, #333333);
+      --protvista-datatable-bg-base: var(
+        --protvista-dt-bg-base,
+        var(--protvista-color-surface, #ffffff)
+      );
+      --protvista-datatable-bg-header: var(--protvista-dt-bg-header, #f8f8f8);
+      --protvista-datatable-bg-hover: var(--protvista-dt-bg-hover, #f1f7ff);
+      --protvista-datatable-bg-active: var(--protvista-dt-bg-active, #e6f3ff);
+      --protvista-datatable-border: var(--protvista-dt-border, #e0e0e0);
+      --protvista-datatable-border-input: var(
+        --protvista-dt-border-input,
+        #767676
+      );
+      --protvista-datatable-shadow-header: var(
+        --protvista-dt-shadow-header,
+        #cccccc
+      );
     }
 
     .scroll-container {
@@ -83,26 +102,26 @@ export class ProtvistaUniprotDatatable<
       overflow-y: auto;
       overflow-x: auto;
       -webkit-overflow-scrolling: touch;
-      border: 1px solid var(--protvista-dt-border);
-      background: var(--protvista-dt-bg-base);
+      border: 1px solid var(--protvista-datatable-border);
+      background: var(--protvista-datatable-bg-base);
     }
 
     table {
       width: 100%;
       border-collapse: collapse;
       font-size: 0.9rem;
-      color: var(--protvista-dt-text-body);
+      color: var(--protvista-datatable-text-body);
     }
 
     thead th {
       position: sticky;
       top: 0;
       z-index: 2;
-      background: var(--protvista-dt-bg-header);
+      background: var(--protvista-datatable-bg-header);
       text-transform: uppercase;
       font-size: 0.75rem;
       letter-spacing: 0.05em;
-      box-shadow: 0 1px 0 var(--protvista-dt-shadow-header);
+      box-shadow: 0 1px 0 var(--protvista-datatable-shadow-header);
     }
 
     th {
@@ -111,12 +130,12 @@ export class ProtvistaUniprotDatatable<
       white-space: nowrap;
       vertical-align: top;
       font-weight: 700;
-      color: var(--protvista-dt-text-head);
+      color: var(--protvista-datatable-text-head);
     }
 
     td {
       padding: 0.75rem 0.5rem;
-      border-bottom: 1px solid var(--protvista-dt-border);
+      border-bottom: 1px solid var(--protvista-datatable-border);
       vertical-align: middle;
     }
 
@@ -127,20 +146,20 @@ export class ProtvistaUniprotDatatable<
     }
 
     tbody tr:hover {
-      background-color: var(--protvista-dt-bg-hover);
+      background-color: var(--protvista-datatable-bg-hover);
     }
 
     tbody tr:focus-visible {
-      background-color: var(--protvista-dt-bg-hover);
-      outline: 2px solid var(--protvista-dt-primary);
+      background-color: var(--protvista-datatable-bg-hover);
+      outline: 2px solid var(--protvista-datatable-accent);
       outline-offset: -2px;
       position: relative;
       z-index: 1;
     }
 
     tbody tr.active {
-      background-color: var(--protvista-dt-bg-active);
-      box-shadow: inset 4px 0 0 var(--protvista-dt-primary);
+      background-color: var(--protvista-datatable-bg-active);
+      box-shadow: inset 4px 0 0 var(--protvista-datatable-accent);
     }
 
     .header-content {
@@ -154,22 +173,44 @@ export class ProtvistaUniprotDatatable<
       padding: 0.4rem;
       font-size: 0.85rem;
       width: 100%;
-      border: 1px solid var(--protvista-dt-border-input);
-      border-radius: 4px;
-      background-color: var(--protvista-dt-bg-base);
-      color: var(--protvista-dt-text-input);
+      border: 1px solid var(--protvista-datatable-border-input);
+      border-radius: var(--protvista-radius, 4px);
+      background-color: var(--protvista-datatable-bg-base);
+      color: var(--protvista-datatable-text-input);
     }
 
     select:focus {
-      outline: 2px solid var(--protvista-dt-primary);
-      border-color: var(--protvista-dt-primary);
+      outline: 2px solid var(--protvista-datatable-accent);
+      border-color: var(--protvista-datatable-accent);
     }
 
     .no-results {
       text-align: center;
       padding: 3rem;
-      color: var(--protvista-dt-text-muted);
+      color: var(--protvista-datatable-text-muted);
       font-style: italic;
+    }
+
+    /* Utility classes for link content rendered into cells (e.g. the
+       structure component's Source / Foldseek links). They live here,
+       not in the caller, because cell content renders inside this
+       shadow root where the caller's global stylesheet cannot reach. */
+    .cell-link {
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .cell-link__icon {
+      display: inline-flex;
+      width: 0.9em;
+      height: 0.9em;
+    }
+
+    .cell-link__icon--sm {
+      width: 0.8em;
+      height: 0.8em;
     }
   `;
 
@@ -395,6 +436,7 @@ export class ProtvistaUniprotDatatable<
 
     return html`
       <select
+        part="filter-select"
         aria-label=${ifDefined(
           col.label ? `Filter by ${col.label}` : undefined
         )}
@@ -412,7 +454,7 @@ export class ProtvistaUniprotDatatable<
   private renderNoResults() {
     return html`
       <tr>
-        <td colspan=${this.columns.length} class="no-results">
+        <td colspan=${this.columns.length} class="no-results" part="no-results">
           No matching results found
         </td>
       </tr>
@@ -421,13 +463,13 @@ export class ProtvistaUniprotDatatable<
 
   override render() {
     return html`
-      <div class="scroll-container">
-        <table>
-          <thead>
+      <div class="scroll-container" part="scroll-container">
+        <table part="table">
+          <thead part="header">
             <tr>
               ${this.columns.map(
                 (col) => html`
-                  <th scope="col">
+                  <th scope="col" part="header-cell">
                     <div class="header-content">
                       <span>${col.label}</span>
                       ${this.renderFilterDropdown(col)}
@@ -461,12 +503,13 @@ export class ProtvistaUniprotDatatable<
                   <tr
                     data-id=${id || ''}
                     class=${isSelected ? 'active' : ''}
+                    part=${isSelected ? 'row row-active' : 'row'}
                     role="option"
                     aria-selected=${isSelected ? 'true' : 'false'}
                     tabindex=${isFocusable ? '0' : '-1'}
                   >
                     ${this.columns.map(
-                      (col) => html`<td>${this.renderCell(col, row)}</td>`
+                      (col) => html`<td part="cell">${this.renderCell(col, row)}</td>`
                     )}
                   </tr>
                 `;

--- a/src/protvista-uniprot-structure.ts
+++ b/src/protvista-uniprot-structure.ts
@@ -12,6 +12,7 @@ import externalLinkIcon from './icons/external-link.svg';
 
 import loaderIcon from './icons/spinner.svg';
 import loaderStyles from './styles/loader-styles';
+import { injectStyleOnce, installTokenDefaults } from './styles/inject';
 
 const PDBLinks = [
   { name: 'PDBe', link: 'https://www.ebi.ac.uk/pdbe-srv/view/entry/' },
@@ -280,26 +281,28 @@ const process3DBeaconsData = (
   );
 };
 
+// The legend swatch colours mirror the AlphaFold pLDDT / AlphaMissense
+// pathogenicity ramps used by the track rendering — they are data
+// encodings, not themable UI, so they live as fixed values in classed
+// rules (see `cssStyle`) rather than `--protvista-*` tokens. Classing
+// them (instead of inline `style=`) keeps the template CSP-clean.
 const AFMetaInfo = html`
   <strong>Model Confidence:</strong>
   <ul class="no-bullet">
     <li>
-      <span class="af-legend" style="background-color: rgb(0, 83, 214)"></span>
+      <span class="af-legend af-legend--very-high"></span>
       Very high (pLDDT > 90)
     </li>
     <li>
-      <span
-        class="af-legend"
-        style="background-color: rgb(101, 203, 243)"
-      ></span>
+      <span class="af-legend af-legend--confident"></span>
       Confident (90 > pLDDT > 70)
     </li>
     <li>
-      <span class="af-legend" style="background-color:rgb(255, 219, 19)"></span>
+      <span class="af-legend af-legend--low"></span>
       Low (70 > pLDDT > 50)
     </li>
     <li>
-      <span class="af-legend" style="background-color:rgb(255, 125, 69)"></span>
+      <span class="af-legend af-legend--very-low"></span>
       Very low (pLDDT < 50)
     </li>
   </ul>
@@ -313,18 +316,15 @@ const AMMetaInfo = html`
   <strong>Model Pathogenicity:</strong>
   <ul class="no-bullet">
     <li>
-      <span class="af-legend" style="background-color: rgb(154, 19, 26)"></span>
+      <span class="af-legend af-legend--am-pathogenic"></span>
       Likely pathogenic (score > 0.564)
     </li>
     <li>
-      <span
-        class="af-legend"
-        style="background-color: rgb(168, 169, 173)"
-      ></span>
+      <span class="af-legend af-legend--am-uncertain"></span>
       Uncertain (0.564 >= score >= 0.34)
     </li>
     <li>
-      <span class="af-legend" style="background-color: rgb(61, 84, 147)"></span>
+      <span class="af-legend af-legend--am-benign"></span>
       Likely benign (score < 0.34)
     </li>
   </ul>
@@ -335,17 +335,21 @@ const AMMetaInfo = html`
   </p>
 `;
 
+// These links are rendered as datatable cell content, i.e. inside the
+// datatable's shadow root — so their layout is styled by the datatable's
+// own `.cell-link` utility classes (see protvista-uniprot-datatable.ts),
+// not the structure component's global stylesheet, which cannot reach
+// into the shadow tree. Classing (instead of inline `style=`) keeps the
+// markup CSP-clean.
 const sourceDownloadLink = (downloadUrl: string) =>
   html`<a
     href="${downloadUrl}"
     aria-label="Download source file"
     title="Download source file"
-    style="text-decoration: none; display: inline-flex; align-items: center; gap: 4px;"
+    class="cell-link"
   >
     Source
-    <span style="display: inline-flex; width: 0.9em; height: 0.9em;">
-      ${svg`${unsafeHTML(downloadIcon)}`}
-    </span>
+    <span class="cell-link__icon">${svg`${unsafeHTML(downloadIcon)}`}</span>
   </a>`;
 
 const foldseekLink = (accession: string, sourceDB: string) => {
@@ -356,12 +360,12 @@ const foldseekLink = (accession: string, sourceDB: string) => {
     rel="noopener noreferrer"
     aria-label="Open Foldseek in a new tab"
     title="Open Foldseek in a new tab"
-    style="text-decoration: none; display: inline-flex; align-items: center; gap: 4px;"
+    class="cell-link"
   >
     Foldseek
-    <span style="display: inline-flex; width: 0.8em; height: 0.8em;">
-      ${svg`${unsafeHTML(externalLinkIcon)}`}
-    </span>
+    <span class="cell-link__icon cell-link__icon--sm"
+      >${svg`${unsafeHTML(externalLinkIcon)}`}</span
+    >
   </a>`;
 };
 
@@ -580,25 +584,16 @@ class ProtvistaUniprotStructure extends LitElement {
     this.onRowSelected(data[0]);
   }
 
-  disconnectedCallback() {
-    this.removeStyles();
-  }
-
   addStyles() {
-    // We are not using static get styles() as we are not using the shadowDOM because of Mol*
-    if (!document.getElementById(styleId)) {
-      const styleTag = document.createElement('style');
-      styleTag.id = styleId;
-      styleTag.textContent = `
-      ${loaderStyles.toString()}
-      ${this.cssStyle}
-      `;
-      document.querySelector('head')?.append(styleTag);
-    }
-  }
-
-  removeStyles() {
-    document.getElementById(styleId)?.remove();
+    // We are not using static get styles() as we are not using the shadowDOM because of Mol*.
+    // Shared, keyed, install-once stylesheets (see src/styles/inject.ts):
+    // the token defaults and loader styles are shared with
+    // <protvista-uniprot>. These are never removed on disconnect — the
+    // shared nodes back every instance, so tearing one down would strip
+    // styling from any other viewer still on the page.
+    installTokenDefaults();
+    injectStyleOnce('loader', loaderStyles.toString());
+    injectStyleOnce(styleId, ProtvistaUniprotStructure.cssStyle.toString());
   }
 
   private onRowSelected(row: ProcessedStructureData) {
@@ -633,8 +628,9 @@ class ProtvistaUniprotStructure extends LitElement {
     this.onRowSelected(e.detail);
   };
 
-  get cssStyle() {
-    return css`
+  // Built once at class definition rather than per instance: addStyles()
+  // runs in every constructor but the sheet is injected only once.
+  private static readonly cssStyle = css`
       .protvista-uniprot-structure {
         line-height: normal;
       }
@@ -681,12 +677,36 @@ class ProtvistaUniprotStructure extends LitElement {
         height: 16px;
       }
 
+      /* Legend swatch colours: fixed data encodings mirroring the
+         AlphaFold pLDDT / AlphaMissense pathogenicity ramps (not themable
+         UI). Classed here rather than set via inline style= on the span. */
+      .protvista-uniprot-structure__meta .af-legend--very-high {
+        background-color: rgb(0, 83, 214);
+      }
+      .protvista-uniprot-structure__meta .af-legend--confident {
+        background-color: rgb(101, 203, 243);
+      }
+      .protvista-uniprot-structure__meta .af-legend--low {
+        background-color: rgb(255, 219, 19);
+      }
+      .protvista-uniprot-structure__meta .af-legend--very-low {
+        background-color: rgb(255, 125, 69);
+      }
+      .protvista-uniprot-structure__meta .af-legend--am-pathogenic {
+        background-color: rgb(154, 19, 26);
+      }
+      .protvista-uniprot-structure__meta .af-legend--am-uncertain {
+        background-color: rgb(168, 169, 173);
+      }
+      .protvista-uniprot-structure__meta .af-legend--am-benign {
+        background-color: rgb(61, 84, 147);
+      }
+
       .am-disabled * {
         cursor: not-allowed;
-        color: #808080;
+        color: var(--protvista-color-disabled);
       }
     `;
-  }
 
   /**
    * we need to use the light DOM.

--- a/src/protvista-uniprot.ts
+++ b/src/protvista-uniprot.ts
@@ -57,6 +57,7 @@ import loaderIcon from './icons/spinner.svg';
 import protvistaStyles from './styles/protvista-styles';
 import loaderStyles from './styles/loader-styles';
 import { CSS_PREFIX } from './styles/css-prefix';
+import { injectStyleOnce, installTokenDefaults } from './styles/inject';
 
 // Performance marks emitted at three lifecycle transitions:
 //   protvista:script-start    component connectedCallback runs
@@ -221,17 +222,15 @@ class ProtvistaUniprot extends LitElement {
 
   addStyles() {
     // We are not using static get styles() as we are not using the shadowDOM because of Mol*.
-    // Guard against double-install: without this, every <protvista-uniprot>
-    // instance on a page would append its own copy of the stylesheet to
-    // <head>. The marker attribute lets every instance share a single
-    // stylesheet node. (Multi-instance isolation — unique DOM ids, scoped
-    // tooltip popovers, etc. — is tracked separately as a next-branch
-    // issue; this guard is the speculative-use-case partial credit.)
-    if (document.querySelector('style[data-protvista-uniprot]')) return;
-    const styleTag = document.createElement('style');
-    styleTag.setAttribute('data-protvista-uniprot', '');
-    styleTag.textContent = `${protvistaStyles.toString()} ${loaderStyles.toString()}`;
-    document.querySelector('head')?.append(styleTag);
+    // Each stylesheet is installed once per page and shared by every
+    // instance (see src/styles/inject.ts). The token defaults and loader
+    // styles carry their own keys so they are shared with
+    // <protvista-uniprot-structure> rather than duplicated. (Multi-instance
+    // isolation — unique DOM ids, scoped tooltip popovers, etc. — is
+    // tracked separately as a next-branch issue.)
+    installTokenDefaults();
+    injectStyleOnce('loader', loaderStyles.toString());
+    injectStyleOnce('viewer', protvistaStyles.toString());
   }
 
   registerWebComponents() {

--- a/src/styles/__spec__/theming.spec.ts
+++ b/src/styles/__spec__/theming.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * Locks in the public theming surface introduced by the styling
+ * modernisation: the design-token registry, the light-DOM default
+ * block, the datatable's `::part` attributes, and the drift guards that
+ * keep the datatable `:host` defaults and `docs/theming.md` in lock-step
+ * with the registry (which calls itself the single source of truth).
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TOKENS, tokenDefaults } from '../tokens';
+import { installTokenDefaults } from '../inject';
+import {
+  ProtvistaUniprotDatatable,
+  type ColumnConfig,
+} from '../../protvista-uniprot-datatable';
+
+/**
+ * Resolve a registry default to the literal it ultimately renders as: a
+ * bare `var(--protvista-global)` reference resolves to that global
+ * token's own default. Used to compare registry defaults against the CSS
+ * that actually ships.
+ */
+function resolveDefault(def: string): string {
+  const m = def.match(/^var\((--protvista-[a-z0-9-]+)\)$/);
+  if (!m) return def;
+  return TOKENS.find((t) => t.name === m[1])?.default ?? def;
+}
+
+describe('design-token registry', () => {
+  it('every token is well-formed and uniquely named', () => {
+    const names = new Set<string>();
+    for (const t of TOKENS) {
+      expect(t.name).toMatch(/^--protvista-[a-z0-9-]+$/);
+      expect(t.default.length).toBeGreaterThan(0);
+      expect(t.description.length).toBeGreaterThan(0);
+      expect(['color', 'length', 'font', 'shadow']).toContain(t.type);
+      expect(names.has(t.name), `duplicate token ${t.name}`).toBe(false);
+      names.add(t.name);
+    }
+  });
+
+  it('token references only point at other declared tokens', () => {
+    const names = new Set(TOKENS.map((t) => t.name));
+    for (const t of TOKENS) {
+      const refs = [...t.default.matchAll(/var\((--[a-z0-9-]+)/g)].map(
+        (m) => m[1]
+      );
+      for (const ref of refs) {
+        expect(names.has(ref), `${t.name} references unknown ${ref}`).toBe(
+          true
+        );
+      }
+    }
+  });
+});
+
+describe('light-DOM token defaults', () => {
+  it('emits a declaration for every non-datatable token', () => {
+    const css = tokenDefaults();
+    for (const t of TOKENS) {
+      if (t.group === 'datatable') {
+        // Datatable declares its own :host defaults (with aliases).
+        expect(css).not.toContain(`${t.name}:`);
+      } else {
+        expect(css).toContain(`${t.name}: ${t.default};`);
+      }
+    }
+  });
+
+  it('installs defaults on :where(:root) so ancestor overrides win', () => {
+    installTokenDefaults();
+    const node = document.head.querySelector(
+      'style[data-protvista-style="tokens"]'
+    );
+    // Declaring on :root (not the host tags) is load-bearing: a value set
+    // directly on the host would shadow a consumer's `:root { … }`
+    // override. :where() keeps it at specificity 0 so the override wins.
+    expect(node?.textContent).toContain(':where(:root)');
+    expect(node?.textContent).toContain('--protvista-color-accent: #0053d6;');
+  });
+});
+
+describe('datatable defaults stay in sync with the registry', () => {
+  const raw = (ProtvistaUniprotDatatable as unknown as { styles: unknown })
+    .styles;
+  const cssText = Array.isArray(raw) ? raw.map(String).join('\n') : String(raw);
+  const datatableTokens = TOKENS.filter((t) => t.group === 'datatable');
+
+  it('ships every datatable token with its registry default value', () => {
+    for (const t of datatableTokens) {
+      expect(cssText, `${t.name} absent from datatable CSS`).toContain(t.name);
+      const lit = resolveDefault(t.default);
+      expect(cssText, `${t.name} default (${lit}) drifted from registry`).toContain(
+        lit
+      );
+    }
+  });
+
+  it('declares no datatable custom property missing from the registry', () => {
+    const declared = new Set(
+      [...cssText.matchAll(/(--protvista-datatable-[a-z-]+)\s*:/g)].map(
+        (m) => m[1]
+      )
+    );
+    const known = new Set(datatableTokens.map((t) => t.name));
+    for (const name of declared) {
+      expect(known.has(name), `${name} declared but not in registry`).toBe(
+        true
+      );
+    }
+  });
+});
+
+describe('docs/theming.md stays in sync with the registry', () => {
+  // Vitest runs from the repo root, so resolve the docs path from cwd.
+  const docs = readFileSync(join(process.cwd(), 'docs/theming.md'), 'utf8');
+
+  it('documents every token name and its default value', () => {
+    for (const t of TOKENS) {
+      expect(docs, `${t.name} missing from docs`).toContain(t.name);
+      expect(docs, `default for ${t.name} missing from docs`).toContain(
+        t.default
+      );
+    }
+  });
+});
+
+describe('datatable ::part surface', () => {
+  let el: HTMLElement & {
+    columns: ReadonlyArray<ColumnConfig<{ id: string }>>;
+    data: ReadonlyArray<{ id: string }>;
+    selectedId?: string;
+    updateComplete: Promise<unknown>;
+  };
+
+  beforeEach(async () => {
+    el = document.createElement('protvista-uniprot-datatable') as never;
+    el.columns = [{ key: 'id', label: 'ID', filterable: true }];
+    el.data = [{ id: '1' }, { id: '2' }];
+    document.body.append(el);
+    await el.updateComplete;
+  });
+
+  afterEach(() => {
+    el.remove();
+  });
+
+  const parts = () =>
+    [...el.shadowRoot!.querySelectorAll('[part]')].flatMap((n) =>
+      (n.getAttribute('part') || '').split(/\s+/)
+    );
+
+  it('exposes the documented structural parts', () => {
+    const found = new Set(parts());
+    for (const p of [
+      'scroll-container',
+      'table',
+      'header',
+      'header-cell',
+      'filter-select',
+      'row',
+      'cell',
+    ]) {
+      expect(found.has(p), `missing part="${p}"`).toBe(true);
+    }
+  });
+
+  it('marks the selected row with the row-active part', async () => {
+    el.selectedId = '1';
+    await el.updateComplete;
+    const active = el.shadowRoot!.querySelector('tr.active');
+    expect(active?.getAttribute('part')).toContain('row-active');
+  });
+});
+
+describe('runtime theming (the no-code substrate)', () => {
+  it('every registry token is a valid, runtime-settable custom property', () => {
+    // A no-code panel drives theming by writing each token via
+    // style.setProperty; this proves every registry name is a
+    // syntactically valid custom property that round-trips.
+    const el = document.createElement('div');
+    for (const t of TOKENS) {
+      el.style.setProperty(t.name, 'rgb(1, 2, 3)');
+      expect(
+        el.style.getPropertyValue(t.name),
+        `${t.name} is not a settable custom property`
+      ).toBe('rgb(1, 2, 3)');
+      el.style.removeProperty(t.name);
+    }
+  });
+});

--- a/src/styles/inject.ts
+++ b/src/styles/inject.ts
@@ -1,0 +1,57 @@
+import { tokenDefaultsBlock } from './tokens';
+
+/**
+ * Shared light-DOM stylesheet injection.
+ *
+ * Both `<protvista-uniprot>` and `<protvista-uniprot-structure>` render
+ * in light DOM (because of Mol*), so their styles live in the document's
+ * global scope rather than a shadow root. Every instance on a page
+ * shares one `<style>` node per key: the first mount installs it, later
+ * mounts are no-ops. Keys are used (rather than one blob) so the token
+ * defaults and the loader styles are installed once and shared, while
+ * each component owns its own component-styles sheet.
+ *
+ * These sheets are install-once and page-lifetime: they are never
+ * removed on disconnect, because a single shared node backs every
+ * instance — tearing it down when one element unmounts would strip
+ * styling from the others still on the page.
+ */
+
+const MARKER = 'data-protvista-style';
+
+/** Idempotently install a keyed `<style>` into `<head>`. */
+export function injectStyleOnce(key: string, cssText: string): void {
+  if (typeof document === 'undefined') return;
+  const head = document.head;
+  if (!head) return;
+  if (head.querySelector(`style[${MARKER}="${key}"]`)) return;
+  const styleTag = document.createElement('style');
+  styleTag.setAttribute(MARKER, key);
+  styleTag.textContent = cssText;
+  head.append(styleTag);
+}
+
+/**
+ * The `--protvista-*` design-token defaults, declared on `:where(:root)`.
+ *
+ * Declaring on the document root (not on the host tags) is what makes
+ * the documented theming recipes work: a value declared *directly* on an
+ * element always beats one *inherited* from an ancestor, so putting the
+ * defaults on the host element would shadow a consumer's
+ * `:root { --protvista-…: … }` override. On `:root` instead, the value
+ * inherits down to every viewer element (and into child shadow roots),
+ * and any consumer override — on `:root`, on an ancestor, on the host
+ * element, or inline via `style.setProperty` — takes precedence.
+ *
+ * `:where(:root)` keeps the defaults at specificity 0 so that even a
+ * consumer's own `:root { … }` rule (specificity 0,1,0) wins, regardless
+ * of source order — our sheet is injected late, at mount time.
+ *
+ * Computed once at module load rather than per `addStyles()` call.
+ */
+const TOKEN_DEFAULTS_CSS = tokenDefaultsBlock(':where(:root)');
+
+/** Install the token defaults once for the whole page. */
+export function installTokenDefaults(): void {
+  injectStyleOnce('tokens', TOKEN_DEFAULTS_CSS);
+}

--- a/src/styles/loader-styles.ts
+++ b/src/styles/loader-styles.ts
@@ -11,10 +11,10 @@ export default css`
   }
 
   .protvista-no-results {
-    background-color: #e4e8eb;
+    background-color: var(--protvista-no-results-bg);
     display: flex;
     justify-content: center;
     padding: 1rem;
-    font-size: 0.8rem;
+    font-size: var(--protvista-font-size);
   }
 `;

--- a/src/styles/protvista-styles.ts
+++ b/src/styles/protvista-styles.ts
@@ -22,6 +22,12 @@ import { CSS_PREFIX } from './css-prefix';
  *      isn't a descendant of `<protvista-uniprot>`, so we can't bleed
  *      onto a consumer's own elements anywhere else on the page.
  *
+ * Colours, sizes, and other themable values are read from the
+ * `--protvista-*` design tokens (see `src/styles/tokens.ts`); their
+ * defaults are injected on the `protvista-uniprot` host at render time
+ * and inherit here, so consumers retheme by overriding a token rather
+ * than by targeting these (private, hash-prefixed) class names.
+ *
  * The single exception is `.feature` (below): it is deliberately left
  * unprefixed because the component never *applies* that class itself —
  * the rule styles feature glyphs rendered by Nightingale child
@@ -30,7 +36,7 @@ import { CSS_PREFIX } from './css-prefix';
 const p = unsafeCSS(CSS_PREFIX);
 export default css`
   protvista-uniprot .${p}-track-content {
-    width: 80vw;
+    width: var(--protvista-track-content-width);
   }
 
   protvista-uniprot .${p}-track-content__coloured-sequence {
@@ -53,14 +59,14 @@ export default css`
   protvista-uniprot .${p}-track-label,
   protvista-uniprot .${p}-nav-track-label,
   protvista-uniprot .${p}-credits {
-    min-width: 20vw;
-    max-width: 20vw;
+    min-width: var(--protvista-label-width);
+    max-width: var(--protvista-label-width);
     padding: 0.5em;
     line-height: normal;
   }
 
   protvista-uniprot .${p}-group-label {
-    background-color: #b2f5ff;
+    background-color: var(--protvista-group-label-bg);
     cursor: pointer;
   }
 
@@ -71,7 +77,7 @@ export default css`
     height: 0;
     border-top: 5px solid transparent;
     border-bottom: 5px solid transparent;
-    border-left: 5px solid #333;
+    border-left: 5px solid var(--protvista-caret-color);
     margin-right: 5px;
     -webkit-transition: all 0.1s;
     /* Safari */
@@ -86,27 +92,27 @@ export default css`
     height: 0;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    border-top: 5px solid #333;
+    border-top: 5px solid var(--protvista-caret-color);
     margin-right: 5px;
   }
 
   protvista-uniprot .${p}-track-label {
-    background-color: #d9faff;
+    background-color: var(--protvista-track-label-bg);
   }
 
   protvista-uniprot nightingale-track-canvas {
-    border-top: 1px solid #d9faff;
+    border-top: 1px solid var(--protvista-track-border-color);
   }
 
   protvista-uniprot nightingale-navigation .handle {
-    fill: darkgrey;
-    stroke: black;
+    fill: var(--protvista-nav-handle-fill);
+    stroke: var(--protvista-nav-handle-stroke);
     stroke-width: 0.5px;
     height: 19px;
   }
 
   protvista-uniprot nightingale-filter {
-    font-size: 0.8rem;
+    font-size: var(--protvista-font-size);
   }
 
   /* Intentionally unprefixed: styles feature glyphs rendered by
@@ -121,7 +127,7 @@ export default css`
    *
    * The popover is a plain <div role="tooltip"> attached to the host's
    * light DOM. Floating UI handles positioning via an inline
-   * \`transform\`; everything else is themable here.
+   * \`transform\`; everything else is themable via \`--protvista-tooltip-*\`.
    *
    * Layout: the resolver emits a flat \`<h5>Label</h5><p>value</p>\`
    * stream per field. We turn that into a dense two-column grid
@@ -130,15 +136,15 @@ export default css`
    * compact definition-list look.
    * ------------------------------------------------------------------------- */
   protvista-uniprot .protvista-tooltip {
-    background: #fff;
-    color: #222;
-    border: 1px solid #c5c8cc;
-    border-radius: 4px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    background: var(--protvista-tooltip-bg);
+    color: var(--protvista-tooltip-color);
+    border: 1px solid var(--protvista-tooltip-border);
+    border-radius: var(--protvista-radius);
+    box-shadow: var(--protvista-shadow-popover);
     padding: 0.5em 0.75em;
-    font-size: 0.8rem;
+    font-size: var(--protvista-font-size);
     line-height: 1.35;
-    max-width: 320px;
+    max-width: var(--protvista-tooltip-max-width);
   }
 
   protvista-uniprot .protvista-tooltip .content {
@@ -155,7 +161,7 @@ export default css`
     padding: 0;
     font-size: inherit;
     font-weight: 600;
-    color: #4a5056;
+    color: var(--protvista-color-text-muted);
     white-space: nowrap;
   }
 
@@ -188,22 +194,22 @@ export default css`
      selector matches plain sides plus the -start / -end variants
      flip() can produce. */
   protvista-uniprot .protvista-tooltip .arrow {
-    background: #fff;
+    background: var(--protvista-tooltip-bg);
   }
   protvista-uniprot .protvista-tooltip[data-placement^='top'] .arrow {
-    border-right: 1px solid #c5c8cc;
-    border-bottom: 1px solid #c5c8cc;
+    border-right: 1px solid var(--protvista-tooltip-border);
+    border-bottom: 1px solid var(--protvista-tooltip-border);
   }
   protvista-uniprot .protvista-tooltip[data-placement^='bottom'] .arrow {
-    border-left: 1px solid #c5c8cc;
-    border-top: 1px solid #c5c8cc;
+    border-left: 1px solid var(--protvista-tooltip-border);
+    border-top: 1px solid var(--protvista-tooltip-border);
   }
   protvista-uniprot .protvista-tooltip[data-placement^='left'] .arrow {
-    border-top: 1px solid #c5c8cc;
-    border-right: 1px solid #c5c8cc;
+    border-top: 1px solid var(--protvista-tooltip-border);
+    border-right: 1px solid var(--protvista-tooltip-border);
   }
   protvista-uniprot .protvista-tooltip[data-placement^='right'] .arrow {
-    border-bottom: 1px solid #c5c8cc;
-    border-left: 1px solid #c5c8cc;
+    border-bottom: 1px solid var(--protvista-tooltip-border);
+    border-left: 1px solid var(--protvista-tooltip-border);
   }
 `;

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -1,0 +1,357 @@
+/**
+ * Design-token registry — the single source of truth for every themable
+ * CSS custom property the viewer exposes to library consumers.
+ *
+ * Why a structured registry rather than a hand-written CSS string: one
+ * typed list is the reference for every place these tokens appear —
+ *
+ *   1. the light-DOM CSS default block, which is *generated* from this
+ *      registry at render time (`tokenDefaults`);
+ *   2. the datatable's shadow `:host` defaults and the reference table
+ *      in `docs/theming.md`, which are hand-written (the datatable
+ *      carries back-compat aliases; the docs add prose) but are held in
+ *      lock-step with this registry by drift-guard tests in
+ *      `src/styles/__spec__/theming.spec.ts`; and
+ *   3. (future) a no-code styling panel, which can enumerate `TOKENS`,
+ *      render one typed control per entry, and write overrides with
+ *      `element.style.setProperty(name, value)`.
+ *
+ * Custom properties are runtime-settable and inherit down the tree —
+ * including *into* the datatable's shadow root — so a consumer (or that
+ * future panel) themes the whole viewer by setting these on `:root`, on
+ * the `<protvista-uniprot>` host, or on any ancestor (see
+ * `installTokenDefaults` for why the defaults live on `:root`). Defaults
+ * equal the historical hardcoded literals, so a viewer with no consumer
+ * CSS renders identically.
+ *
+ * Scope: this covers *chrome/UI* styling only. Data-domain colours
+ * (AlphaFold pLDDT / AlphaMissense ramps, variant and PTM-tier colours)
+ * are deliberately excluded — they are semantic data encodings themed
+ * through the config's `registerTheme()` path, not the interface.
+ */
+
+export type TokenType = 'color' | 'length' | 'font' | 'shadow';
+
+export interface TokenDef {
+  /** The custom-property name, e.g. `--protvista-color-accent`. */
+  name: string;
+  /** Grouping for docs / a future panel: the tier or component it themes. */
+  group: 'global' | 'viewer' | 'tooltip' | 'datatable';
+  /** Coarse value kind, so a no-code UI can pick the right control. */
+  type: TokenType;
+  /**
+   * The default value emitted into the CSS default block. May itself be
+   * a `var(--other-token)` reference so a component token inherits from
+   * the global tier while still being independently overridable.
+   */
+  default: string;
+  /** One-line description for the docs table / control label. */
+  description: string;
+}
+
+/**
+ * Global tier — the small set of tokens a consumer reaches for first.
+ * Component tokens below default *from* these, so overriding one global
+ * (e.g. `--protvista-color-accent`) cascades everywhere it is used.
+ */
+const GLOBAL_TOKENS: TokenDef[] = [
+  {
+    name: '--protvista-font-family',
+    group: 'global',
+    type: 'font',
+    default: 'inherit',
+    description: 'Base font family for viewer chrome (labels, tooltips, table).',
+  },
+  {
+    name: '--protvista-font-size',
+    group: 'global',
+    type: 'length',
+    default: '0.8rem',
+    description: 'Base font size for viewer chrome.',
+  },
+  {
+    name: '--protvista-color-accent',
+    group: 'global',
+    type: 'color',
+    default: '#0053d6',
+    description: 'Accent colour — focus rings, active-row marker, primary UI.',
+  },
+  {
+    name: '--protvista-color-text',
+    group: 'global',
+    type: 'color',
+    default: '#222222',
+    description: 'Default body text colour.',
+  },
+  {
+    name: '--protvista-color-text-muted',
+    group: 'global',
+    type: 'color',
+    default: '#4a5056',
+    description: 'Muted/secondary text colour (tooltip labels, captions).',
+  },
+  {
+    name: '--protvista-color-surface',
+    group: 'global',
+    type: 'color',
+    default: '#ffffff',
+    description: 'Surface/background colour for popovers and panels.',
+  },
+  {
+    name: '--protvista-color-border',
+    group: 'global',
+    type: 'color',
+    default: '#c5c8cc',
+    description: 'Default border colour for popovers and panels.',
+  },
+  {
+    name: '--protvista-color-disabled',
+    group: 'global',
+    type: 'color',
+    default: '#808080',
+    description: 'Colour for disabled controls.',
+  },
+  {
+    name: '--protvista-radius',
+    group: 'global',
+    type: 'length',
+    default: '4px',
+    description: 'Corner radius for popovers and controls.',
+  },
+  {
+    name: '--protvista-shadow-popover',
+    group: 'global',
+    type: 'shadow',
+    default: '0 4px 12px rgb(0 0 0 / 0.15)',
+    description: 'Drop shadow for floating popovers (tooltips).',
+  },
+];
+
+/** Light-DOM viewer chrome — track/group labels, navigation, empty states. */
+const VIEWER_TOKENS: TokenDef[] = [
+  {
+    name: '--protvista-track-content-width',
+    group: 'viewer',
+    type: 'length',
+    default: '80vw',
+    description: 'Width of the track-content column (the visualisation area).',
+  },
+  {
+    name: '--protvista-label-width',
+    group: 'viewer',
+    type: 'length',
+    default: '20vw',
+    description: 'Width of the label column (group/track/nav labels, credits).',
+  },
+  {
+    name: '--protvista-group-label-bg',
+    group: 'viewer',
+    type: 'color',
+    default: '#b2f5ff',
+    description: 'Background of collapsible group labels.',
+  },
+  {
+    name: '--protvista-track-label-bg',
+    group: 'viewer',
+    type: 'color',
+    default: '#d9faff',
+    description: 'Background of individual track labels.',
+  },
+  {
+    name: '--protvista-track-border-color',
+    group: 'viewer',
+    type: 'color',
+    default: 'var(--protvista-track-label-bg)',
+    description: 'Top border between stacked track-canvas rows.',
+  },
+  {
+    name: '--protvista-caret-color',
+    group: 'viewer',
+    type: 'color',
+    default: '#333333',
+    description: 'Colour of the group-label expand/collapse caret.',
+  },
+  {
+    name: '--protvista-nav-handle-fill',
+    group: 'viewer',
+    type: 'color',
+    default: 'darkgrey',
+    description: 'Fill of the navigation zoom handles.',
+  },
+  {
+    name: '--protvista-nav-handle-stroke',
+    group: 'viewer',
+    type: 'color',
+    default: 'black',
+    description: 'Stroke of the navigation zoom handles.',
+  },
+  {
+    name: '--protvista-no-results-bg',
+    group: 'viewer',
+    type: 'color',
+    default: '#e4e8eb',
+    description: 'Background of the "no results" empty state.',
+  },
+];
+
+/** Click-tooltip popover — defaults inherit from the global tier. */
+const TOOLTIP_TOKENS: TokenDef[] = [
+  {
+    name: '--protvista-tooltip-bg',
+    group: 'tooltip',
+    type: 'color',
+    default: 'var(--protvista-color-surface)',
+    description: 'Tooltip background.',
+  },
+  {
+    name: '--protvista-tooltip-color',
+    group: 'tooltip',
+    type: 'color',
+    default: 'var(--protvista-color-text)',
+    description: 'Tooltip text colour.',
+  },
+  {
+    name: '--protvista-tooltip-border',
+    group: 'tooltip',
+    type: 'color',
+    default: 'var(--protvista-color-border)',
+    description: 'Tooltip border and arrow colour.',
+  },
+  {
+    name: '--protvista-tooltip-max-width',
+    group: 'tooltip',
+    type: 'length',
+    default: '320px',
+    description: 'Maximum tooltip width before text wraps.',
+  },
+];
+
+/**
+ * Datatable (shadow DOM). These are documented here for reference and a
+ * future panel, but the datatable declares its own `:host` defaults
+ * (with back-compat aliases for the former `--protvista-dt-*` names);
+ * the `default` values below are the effective defaults it resolves to.
+ * See `src/protvista-uniprot-datatable.ts`.
+ */
+const DATATABLE_TOKENS: TokenDef[] = [
+  {
+    name: '--protvista-datatable-accent',
+    group: 'datatable',
+    type: 'color',
+    default: 'var(--protvista-color-accent)',
+    description: 'Datatable accent — focus outline, active-row marker.',
+  },
+  {
+    name: '--protvista-datatable-text-head',
+    group: 'datatable',
+    type: 'color',
+    default: '#1a1a1a',
+    description: 'Header-cell text colour.',
+  },
+  {
+    name: '--protvista-datatable-text-body',
+    group: 'datatable',
+    type: 'color',
+    default: '#2c2c2c',
+    description: 'Body-cell text colour.',
+  },
+  {
+    name: '--protvista-datatable-text-muted',
+    group: 'datatable',
+    type: 'color',
+    default: '#444444',
+    description: 'Muted text (e.g. the no-results message).',
+  },
+  {
+    name: '--protvista-datatable-text-input',
+    group: 'datatable',
+    type: 'color',
+    default: '#333333',
+    description: 'Filter <select> text colour.',
+  },
+  {
+    name: '--protvista-datatable-bg-base',
+    group: 'datatable',
+    type: 'color',
+    default: 'var(--protvista-color-surface)',
+    description: 'Datatable base background.',
+  },
+  {
+    name: '--protvista-datatable-bg-header',
+    group: 'datatable',
+    type: 'color',
+    default: '#f8f8f8',
+    description: 'Sticky header-row background.',
+  },
+  {
+    name: '--protvista-datatable-bg-hover',
+    group: 'datatable',
+    type: 'color',
+    default: '#f1f7ff',
+    description: 'Row hover/focus background.',
+  },
+  {
+    name: '--protvista-datatable-bg-active',
+    group: 'datatable',
+    type: 'color',
+    default: '#e6f3ff',
+    description: 'Selected/active-row background.',
+  },
+  {
+    name: '--protvista-datatable-border',
+    group: 'datatable',
+    type: 'color',
+    default: '#e0e0e0',
+    description: 'Cell and container borders.',
+  },
+  {
+    name: '--protvista-datatable-border-input',
+    group: 'datatable',
+    type: 'color',
+    default: '#767676',
+    description: 'Filter <select> border.',
+  },
+  {
+    name: '--protvista-datatable-shadow-header',
+    group: 'datatable',
+    type: 'color',
+    default: '#cccccc',
+    description: 'Under-shadow of the sticky header row.',
+  },
+  {
+    name: '--protvista-datatable-max-height',
+    group: 'datatable',
+    type: 'length',
+    default: '400px',
+    description: 'Max height of the scroll container before it scrolls.',
+  },
+];
+
+/** The full, ordered token vocabulary. */
+export const TOKENS: readonly TokenDef[] = [
+  ...GLOBAL_TOKENS,
+  ...VIEWER_TOKENS,
+  ...TOOLTIP_TOKENS,
+  ...DATATABLE_TOKENS,
+];
+
+/**
+ * The token defaults that live in the light DOM, i.e. everything except
+ * the datatable (which ships its own shadow `:host` defaults). Returns
+ * the declaration lines only — the caller wraps them in a selector.
+ */
+export function tokenDefaults(): string {
+  return TOKENS.filter((t) => t.group !== 'datatable')
+    .map((t) => `  ${t.name}: ${t.default};`)
+    .join('\n');
+}
+
+/**
+ * A complete CSS rule declaring the light-DOM token defaults on the
+ * given selector (the `protvista-uniprot` host tag), so the values
+ * inherit to all descendants — including into child components' shadow
+ * roots via custom-property inheritance.
+ */
+export function tokenDefaultsBlock(selector: string): string {
+  return `${selector} {\n${tokenDefaults()}\n}`;
+}


### PR DESCRIPTION

## Purpose

Addresses https://github.com/ebi-webcomponents/protvista/issues/196

Modernise the styling architecture so consumers can theme the viewer without forking or fighting the stylesheet: introduce a `--protvista-*` design-token registry with runtime-overridable defaults, and expose the datatable's structural elements via `::part`.

## Approach

* Central token registry (`src/styles/tokens.ts`) as the single source of truth for all themable values; defaults injected once per page on `:where(:root)` (specificity 0) so any consumer override wins.
* Shared idempotent light-DOM style injection (`src/styles/inject.ts`) replacing per-component ad-hoc `<style>` handling; hardcoded colours and inline `style` attributes (structure legend/icons) replaced with token references.
* `part` attributes on the shadow-DOM datatable's structural elements (rows, header, cells, filters) for standard `::part` styling; internal class names stay private behind the `CSS_PREFIX` hash.
* Documented the public theming contract in `docs/theming.md` and the design rationale in `specs/styling-architecture.md`.

## Testing

* New `src/styles/__spec__/theming.spec.ts` covering: token registry well-formedness and reference integrity, light-DOM defaults emitted on `:where(:root)` for every token, datatable defaults staying in sync with the registry, `docs/theming.md` staying in sync with the registry (names + defaults), the documented `::part` surface (including `row-active` on selection), and every token being runtime-settable.

## Visual changes

None by default — token defaults reproduce the existing appearance. (Screenshot of a themed instance can be added if useful.)

## Checklist

- [x] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed by all interested parties.