### PR TITLE
Examples directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The viewer renders a single collapsible group "Domains" (label title-cased from 
 
 - **Schema reference.** [`specs/config-approach.md`](./specs/config-approach.md) documents every field (`groups`, `tracks`, `sources`, `defaults`, `extends`, `kind`, `data`, `rendering`, `dataTooltip`) with worked examples and edge-case semantics. This is the normative source.
 - **Canonical default.** [`src/default-config.yaml`](./src/default-config.yaml) is the UniProt viewer itself, authored in the new schema. Useful as a reference.
+- **Worked examples.** [`examples/`](./examples) is the canonical, CI-validated set of runnable example configs — one per generic-format adapter (CSV/TSV/JSON/BED), inline data, a minimal URL-sourced config, and an `extends:`-based config that layers a custom track on the shipped default. See [`examples/README.md`](./examples/README.md).
 - **Authoring `dataTooltip`.** [`docs/data-tooltip.md`](./docs/data-tooltip.md) covers the three authoring forms (bare string, `kind: fields`, `kind: markdown`) with examples.
 
 ## Events

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,63 @@
+# ProtVista example configs
+
+This directory is the canonical, CI-validated set of example ProtVista
+viewer configurations. Every subdirectory here is a self-contained
+example — its own `config.yaml` plus any sample data it needs — and is
+automatically schema-validated and smoke-rendered on every push and
+pull request by [`src/__spec__/examples.spec.ts`](../src/__spec__/examples.spec.ts)
+(run via `yarn test:unit`, wired into
+[`.github/workflows/test-and-deploy.yml`](../.github/workflows/test-and-deploy.yml)).
+Adding a new `examples/<name>/config.yaml` directory picks it up
+automatically — no separate list to update.
+
+This is meant to become the single source of truth that the
+playground, Starter Kit, tutorial, and docs eventually all point at,
+rather than each maintaining their own divergent samples.
+
+## What's here
+
+| Directory | Demonstrates |
+| --- | --- |
+| [`basic/`](./basic) | Minimal config: one group, one URL-sourced track against the real UniProt API |
+| [`inline-data/`](./inline-data) | `from: inline` — no network fetch for track data |
+| [`csv/`](./csv) | Bring-your-own CSV file — `features-csv` adapter, inferred from the `.csv` extension |
+| [`tsv/`](./tsv) | Bring-your-own TSV file — `features-tsv` adapter, inferred from the `.tsv` extension |
+| [`json/`](./json) | Bring-your-own JSON file — `features-json` adapter, inferred from the `.json` extension |
+| [`bed/`](./bed) | Bring-your-own BED file — `bed` adapter, inferred from the `.bed` extension |
+| [`extend-default/`](./extend-default) | `extends:` the shipped canonical UniProt config and layers one custom CSV-backed track on top |
+
+Column/shape conventions for the four generic-format adapters (CSV,
+TSV, JSON, BED) are documented in
+[`specs/generic-format-adapters.md`](../specs/generic-format-adapters.md).
+The full config schema is documented in
+[`specs/config-approach.md`](../specs/config-approach.md), which is
+the normative source these examples are drawn from.
+
+## Why every example declares `accession: P05067`
+
+`<protvista-uniprot>` gates its entire load pipeline — including
+purely local or inline track data — behind a truthy `accession`
+(the element fetches the sequence for the accession before loading
+any track). Without an `accession`, even a fully-offline example like
+`inline-data/` would render nothing when mounted standalone. Every
+example here bakes in `P05067` (Amyloid precursor protein — the
+reference accession used across this repo's test suite) purely so it
+is genuinely runnable on its own.
+
+One consequence worth knowing: because of this, mounting even the
+"offline" examples (`inline-data/`, `csv/`, `tsv/`, `json/`, `bed/`)
+for real still performs one network call — the element's top-level
+sequence fetch for `P05067` — even though their own track data never
+touches the network. This is an existing architectural characteristic
+of the element, not something specific to these examples.
+
+## Running an example
+
+Point the `config-src` attribute at any example's config file:
+
+```html
+<protvista-uniprot config-src="./examples/basic/config.yaml"></protvista-uniprot>
+```
+
+or during local development (`yarn start`), edit `index.html` to add
+the tag above and browse to it.

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ rather than each maintaining their own divergent samples.
 | [`inline-data/`](./inline-data) | `from: inline` — no network fetch for track data |
 | [`csv/`](./csv) | Bring-your-own CSV file — `features-csv` adapter, inferred from the `.csv` extension |
 | [`tsv/`](./tsv) | Bring-your-own TSV file — `features-tsv` adapter, inferred from the `.tsv` extension |
-| [`json/`](./json) | Bring-your-own JSON file — `features-json` adapter, inferred from the `.json` extension |
+| [`json/`](./json) | Bring-your-own JSON file — `features-json` adapter, inferred from the `.json` extension (the adapter accepts either `start` or `begin` per record; this example uses `start` throughout) |
 | [`bed/`](./bed) | Bring-your-own BED file — `bed` adapter, inferred from the `.bed` extension |
 | [`extend-default/`](./extend-default) | `extends:` the shipped canonical UniProt config and layers one custom CSV-backed track on top |
 
@@ -61,3 +61,23 @@ Point the `config-src` attribute at any example's config file:
 
 or during local development (`yarn start`), edit `index.html` to add
 the tag above and browse to it.
+
+**Path-resolution caveat.** `<protvista-uniprot>` fetches `config-src`
+itself relative to the hosting page, but everything *inside* the
+fetched config — a track's `data: ./hotspots.csv` shorthand, an
+`extends:` reference — is resolved by the loader's default fetcher as
+a bare `fetch(url)`, which the browser resolves against the *hosting
+page's* URL, not the config file's own directory. This is transparent
+for `basic/` and `inline-data/` (neither references another file), so
+"point `config-src` at any example" is literally true only for those
+two. For the file-backed examples (`csv/`, `tsv/`, `json/`, `bed/`,
+`extend-default/`), the snippet above only resolves correctly when
+the hosting page itself lives in that example's own directory (e.g.
+serve from `examples/csv/` and use `config-src="./config.yaml"`) — a
+page at the repo root loading `config-src="./examples/csv/config.yaml"`
+will fetch `./hotspots.csv` against the repo root instead and render
+that group empty. `extend-default/config.yaml` sidesteps this for its
+own `extends:` target by using an origin-absolute path
+(`/src/default-config.yaml`, see the comment in that file) — but its
+`data: ./hotspots.csv` track is still page-relative like every other
+file-backed example.

--- a/examples/basic/config.yaml
+++ b/examples/basic/config.yaml
@@ -1,0 +1,15 @@
+# Minimal, URL-sourced config — one group, one track.
+#
+# See examples/README.md for how this directory is structured and
+# validated.
+accession: P05067
+sources:
+  features: https://www.ebi.ac.uk/proteins/api/features/{accession}
+groups:
+  - id: DOMAINS
+    tracks:
+      - id: domain
+        kind: features
+        filter: DOMAIN
+        data: features
+        description: Specific combination of secondary structures organized into a characteristic 3D fold

--- a/examples/bed/config.yaml
+++ b/examples/bed/config.yaml
@@ -1,0 +1,11 @@
+# Bring-your-own BED file. The `.bed` extension on `data:` infers the
+# `bed` adapter — no explicit `adapter:` needed.
+accession: P05067
+groups:
+  - id: MY_LAB
+    label: My lab
+    tracks:
+      - id: hotspots
+        kind: features
+        data: ./regions.bed
+        description: Hotspot regions identified by our lab's pipeline

--- a/examples/bed/regions.bed
+++ b/examples/bed/regions.bed
@@ -1,0 +1,5 @@
+# ProtVista example BED file — BED6, 0-based half-open coordinates.
+# chrom is informational only for this single-sequence viewer.
+P05067	17	289	extracellular_domain	800	+
+P05067	344	501	kunitz_domain	650	+
+P05067	699	722	transmembrane_region	500	+

--- a/examples/csv/config.yaml
+++ b/examples/csv/config.yaml
@@ -1,0 +1,11 @@
+# Bring-your-own CSV file. The `.csv` extension on `data:` infers the
+# `features-csv` adapter — no explicit `adapter:` needed.
+accession: P05067
+groups:
+  - id: MY_LAB
+    label: My lab
+    tracks:
+      - id: hotspots
+        kind: features
+        data: ./hotspots.csv
+        description: Hotspot regions identified by our lab's pipeline

--- a/examples/csv/hotspots.csv
+++ b/examples/csv/hotspots.csv
@@ -1,0 +1,5 @@
+type,start,end,description,score
+DOMAIN,18,289,Extracellular domain (custom re-annotation),0.95
+BINDING,132,140,Predicted heparin-binding site,0.87
+REGION,290,340,Acidic-rich linker region,0.6
+MUTAGEN,614,614,Lab-observed loss-of-function point mutation,0.75

--- a/examples/extend-default/config.yaml
+++ b/examples/extend-default/config.yaml
@@ -1,0 +1,25 @@
+# Inherit the full canonical UniProt viewer, then add one custom
+# group backed by a local CSV file. Nothing else needs to be
+# restated — `sources`, `defaults`, all 15 EBI groups, every built-in
+# colour theme: all pulled in from the base.
+#
+# NOTE on the relative `extends:` path: it resolves correctly under a
+# fetcher that resolves paths relative to *this config file's own
+# location* (which is what src/__spec__/examples.spec.ts supplies,
+# and what a deliberately-configured embedder would supply via
+# `loadConfig`'s `extendsFetcher` option). The *default* loader
+# fetcher (`globalThis.fetch`) resolves relative URLs against the
+# *page's* URL, not the config file's location — this is existing
+# `mergeExtends` fetcher behaviour, not specific to this example. See
+# examples/README.md.
+accession: P05067
+extends: ../../src/default-config.yaml
+
+groups:
+  - id: MY_LAB
+    label: My lab
+    tracks:
+      - id: hotspots
+        kind: features
+        data: ./hotspots.csv
+        description: Hotspot regions identified by our lab's pipeline, layered on top of the canonical UniProt viewer

--- a/examples/extend-default/config.yaml
+++ b/examples/extend-default/config.yaml
@@ -3,17 +3,25 @@
 # restated — `sources`, `defaults`, all 15 EBI groups, every built-in
 # colour theme: all pulled in from the base.
 #
-# NOTE on the relative `extends:` path: it resolves correctly under a
-# fetcher that resolves paths relative to *this config file's own
-# location* (which is what src/__spec__/examples.spec.ts supplies,
-# and what a deliberately-configured embedder would supply via
-# `loadConfig`'s `extendsFetcher` option). The *default* loader
-# fetcher (`globalThis.fetch`) resolves relative URLs against the
-# *page's* URL, not the config file's location — this is existing
-# `mergeExtends` fetcher behaviour, not specific to this example. See
-# examples/README.md.
+# NOTE on the `extends:` path being origin-absolute (leading `/`),
+# not `../../src/default-config.yaml`: `<protvista-uniprot>` does not
+# expose any `extendsFetcher` hook to embedders — it always calls
+# `loadConfig` with the library default, which fetches `extends:`
+# targets via bare `globalThis.fetch(url)`. A relative path there
+# resolves against the *hosting page's* URL, not this config file's
+# location, so `../../src/default-config.yaml` would 404 for any page
+# that isn't nested exactly two directories below the repo root. An
+# origin-absolute path resolves correctly under that same default
+# fetcher regardless of which page's `config-src` mounts this file —
+# as long as the page is served from this repo's root (e.g. the dev
+# server, `yarn start`; the built `demo/` bundle does not expose
+# `src/` as static files, so this specific example is a dev-time
+# reference, not something the deployed demo site can mount). See
+# examples/README.md and the "default-fetcher semantics" test in
+# `src/__spec__/examples.spec.ts`, which pins this exact contract
+# against the real, unmodified default fetcher (no CI-only shim).
 accession: P05067
-extends: ../../src/default-config.yaml
+extends: /src/default-config.yaml
 
 groups:
   - id: MY_LAB

--- a/examples/extend-default/hotspots.csv
+++ b/examples/extend-default/hotspots.csv
@@ -1,0 +1,3 @@
+type,start,end,description,score
+DOMAIN,18,289,Custom re-annotation of the extracellular domain,0.9
+BINDING,614,614,Lab-observed candidate binding residue,0.72

--- a/examples/inline-data/config.yaml
+++ b/examples/inline-data/config.yaml
@@ -1,0 +1,21 @@
+# Fully inline data — no `sources`, no file, no network for the track
+# itself. `accession` is still required: the element's top-level
+# sequence fetch is gated on it regardless of where track data comes
+# from. See examples/README.md.
+accession: P05067
+groups:
+  - id: MY_ANNOTATIONS
+    label: My custom annotations
+    tracks:
+      - id: binding_sites
+        label: Predicted binding sites
+        kind: features
+        data:
+          from: inline
+          inlineData:
+            - { type: BINDING, start: 45, end: 52, description: ATP binding }
+            - { type: BINDING, start: 120, end: 128, description: Mg2+ binding }
+        description: Binding sites predicted by my pipeline
+        rendering:
+          color: '#e74c3c'
+          shape: diamond

--- a/examples/json/config.yaml
+++ b/examples/json/config.yaml
@@ -1,0 +1,11 @@
+# Bring-your-own JSON file. The `.json` extension on `data:` infers the
+# `features-json` adapter — no explicit `adapter:` needed.
+accession: P05067
+groups:
+  - id: MY_LAB
+    label: My lab
+    tracks:
+      - id: hotspots
+        kind: features
+        data: ./hotspots.json
+        description: Hotspot regions identified by our lab's pipeline

--- a/examples/json/hotspots.json
+++ b/examples/json/hotspots.json
@@ -1,0 +1,23 @@
+[
+  {
+    "type": "DOMAIN",
+    "begin": 18,
+    "end": 289,
+    "description": "Extracellular domain (custom re-annotation)",
+    "score": 0.95
+  },
+  {
+    "type": "BINDING",
+    "start": 700,
+    "end": 723,
+    "description": "Predicted transmembrane-adjacent binding motif",
+    "score": 0.7
+  },
+  {
+    "type": "REGION",
+    "start": 672,
+    "end": 713,
+    "description": "Custom-called hotspot region",
+    "score": 0.62
+  }
+]

--- a/examples/json/hotspots.json
+++ b/examples/json/hotspots.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "DOMAIN",
-    "begin": 18,
+    "start": 18,
     "end": 289,
     "description": "Extracellular domain (custom re-annotation)",
     "score": 0.95

--- a/examples/tsv/config.yaml
+++ b/examples/tsv/config.yaml
@@ -1,0 +1,11 @@
+# Bring-your-own TSV file. The `.tsv` extension on `data:` infers the
+# `features-tsv` adapter — no explicit `adapter:` needed.
+accession: P05067
+groups:
+  - id: MY_LAB
+    label: My lab
+    tracks:
+      - id: hotspots
+        kind: features
+        data: ./hotspots.tsv
+        description: Hotspot regions identified by our lab's pipeline

--- a/examples/tsv/hotspots.tsv
+++ b/examples/tsv/hotspots.tsv
@@ -1,0 +1,4 @@
+type	start	end	description	score
+DOMAIN	345	501	Kunitz-type protease inhibitor domain (custom)	0.93
+BINDING	551	600	Predicted copper-binding motif	0.81
+REGION	601	650	Juxtamembrane regulatory region	0.55

--- a/specs/generic-format-adapters.md
+++ b/specs/generic-format-adapters.md
@@ -2,10 +2,11 @@
 
 Design for the four generic-format data adapters that let authors point a
 ProtVista track at a CSV / TSV / JSON / BED file without writing
-JavaScript. Not currently implemented; the schema, types, and inference
-plumbing have all been deliberately left out of v1 so the library
-doesn't promise authoring surfaces it can't honour. When built, this
-doc is the implementation brief.
+JavaScript. **Implemented and shipped** — `src/schema/adapters/{features-csv,features-tsv,features-json,bed}.ts`,
+pre-registered by `registerBuiltinAdapters()`, with worked examples
+under [`examples/`](../examples). This doc remains the implementation
+brief / design record; sections describing scope, contracts, and
+column conventions below are still normative.
 
 The four adapters under design:
 

--- a/src/__spec__/examples.spec.ts
+++ b/src/__spec__/examples.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Validates every directory under `examples/` — the canonical,
+ * CI-validated set of example ProtVista viewer configs (see
+ * `examples/README.md`).
+ *
+ * For each `examples/<name>/config.yaml` (discovered dynamically —
+ * no hardcoded list, so new example directories are covered
+ * automatically):
+ *
+ *   1. Schema validation — `loadConfig` must accept it.
+ *   2. Data pipeline — `loadProtvistaData`, driven by the real
+ *      exported `adapters` map (the same one `<protvista-uniprot>`
+ *      uses), must produce `hasData: true` from the example's own
+ *      on-disk sample data. Local (`./`-prefixed) sources are read
+ *      from disk for real, proving the shipped sample files actually
+ *      parse through their real adapter; `https://` sources get an
+ *      inert canned response (safe — `loadProtvistaData` catches
+ *      per-track adapter failures rather than throwing, exactly as
+ *      exercised in `load-data-baseline.spec.ts`).
+ *   3. Render smoke test — mounting a `<protvista-uniprot>` instance
+ *      with that data must produce a populated group/track DOM,
+ *      proving the shape `loadProtvistaData` produced is actually
+ *      renderable, not just structurally valid.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readdirSync, existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { render } from 'lit';
+
+import { loadConfig } from '../schema/load';
+import type { NormalizedConfig } from '../schema/normalize';
+import { loadProtvistaData, type AdapterMap } from '../load-data';
+import { CSS_PREFIX } from '../styles/css-prefix';
+// Side-effect import: registers the `protvista-uniprot` custom
+// element and exposes the real, drift-proof adapter map.
+import '../protvista-uniprot';
+import { adapters as realAdapters } from '../protvista-uniprot';
+
+const REFERENCE_ACCESSION = 'P05067';
+const SEQ_LEN = 770;
+
+const EXAMPLES_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../examples'
+);
+
+interface DiscoveredExample {
+  name: string;
+  dir: string;
+  configPath: string;
+}
+
+function discoverExamples(): DiscoveredExample[] {
+  return readdirSync(EXAMPLES_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const dir = join(EXAMPLES_ROOT, entry.name);
+      return { name: entry.name, dir, configPath: join(dir, 'config.yaml') };
+    })
+    .filter((example) => existsSync(example.configPath))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Canned response for any `https://`-style API source. Shaped like a
+ * real UniProt features payload (`{ features: [...] }`) so the
+ * `uniprot-features-json` adapter — used by `basic/` and inherited by
+ * `extend-default/` via its `extends:` — produces real, non-empty
+ * data; other UniProt-API adapters simply degrade that one track to
+ * empty (per-track try/catch in `loadProtvistaData`), which is fine
+ * here since only the example's own data needs to prove out
+ * end-to-end. `type: 'DOMAIN'` matches `basic/config.yaml`'s
+ * `filter: DOMAIN`, so the track survives the filter pass too.
+ */
+const CANNED_FEATURES_RESPONSE = {
+  features: [{ type: 'DOMAIN', begin: 1, end: 770, description: 'Fixture domain' }],
+};
+
+function makeExampleFetchers(exampleDir: string) {
+  const extendsFetcher = async (ref: string): Promise<string> =>
+    readFile(resolve(exampleDir, ref), 'utf8');
+
+  const fetchOne = async (
+    url: string,
+    responseType: 'json' | 'text'
+  ): Promise<unknown> => {
+    if (/^https?:\/\//i.test(url)) {
+      return responseType === 'json' ? CANNED_FEATURES_RESPONSE : '';
+    }
+    const text = await readFile(resolve(exampleDir, url), 'utf8');
+    return responseType === 'json' ? JSON.parse(text) : text;
+  };
+
+  return { extendsFetcher, fetchOne };
+}
+
+function buildInstance(overrides: Record<string, unknown>) {
+  const el = document.createElement('protvista-uniprot') as any;
+  el.sequence = 'M'.repeat(SEQ_LEN);
+  el.displayCoordinates = { start: 1, end: SEQ_LEN };
+  el.accession = REFERENCE_ACCESSION;
+  el.suspend = false;
+  el.loading = false;
+  el.rawData = {};
+  Object.assign(el, overrides);
+  return el;
+}
+
+describe.each(discoverExamples())('example: $name', ({ dir, configPath }) => {
+  let config: NormalizedConfig;
+
+  beforeAll(async () => {
+    const text = await readFile(configPath, 'utf8');
+    const { extendsFetcher } = makeExampleFetchers(dir);
+    config = await loadConfig(text, {
+      accession: REFERENCE_ACCESSION,
+      extendsFetcher,
+    });
+  });
+
+  it('validates against the schema', () => {
+    expect(config).toBeDefined();
+    expect(config.groups.length).toBeGreaterThan(0);
+  });
+
+  it('loads real on-disk sample data through the real adapter map', async () => {
+    const { fetchOne } = makeExampleFetchers(dir);
+    const result = await loadProtvistaData(
+      REFERENCE_ACCESSION,
+      config,
+      fetchOne,
+      realAdapters as AdapterMap
+    );
+    expect(result.hasData).toBe(true);
+  });
+
+  it('smoke-renders at least one populated group', async () => {
+    const { fetchOne } = makeExampleFetchers(dir);
+    const result = await loadProtvistaData(
+      REFERENCE_ACCESSION,
+      config,
+      fetchOne,
+      realAdapters as AdapterMap
+    );
+
+    const el = buildInstance({
+      config,
+      data: result.data,
+      hasData: result.hasData,
+      openGroups: config.groups.map((g) => g.id),
+    });
+
+    const target = document.createElement('div');
+    render(el.render(), target);
+
+    // A group with no renderable aggregate is legitimately hidden by
+    // the real template (see `hasRenderableData` gating in
+    // `protvista-uniprot.ts`), so this doesn't assert every declared
+    // group renders — just that the example's own data produced at
+    // least one real, populated group/track (the actual smoke-render
+    // guarantee).
+    expect(
+      target.querySelectorAll(`.${CSS_PREFIX}-group`).length
+    ).toBeGreaterThan(0);
+    expect(
+      target.querySelectorAll(`.${CSS_PREFIX}-group__track`).length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/src/__spec__/examples.spec.ts
+++ b/src/__spec__/examples.spec.ts
@@ -5,25 +5,40 @@
  *
  * For each `examples/<name>/config.yaml` (discovered dynamically —
  * no hardcoded list, so new example directories are covered
- * automatically):
+ * automatically; a floor-guard test below pins the expected set so a
+ * discovery-path regression can't silently zero out the whole suite):
  *
  *   1. Schema validation — `loadConfig` must accept it.
  *   2. Data pipeline — `loadProtvistaData`, driven by the real
  *      exported `adapters` map (the same one `<protvista-uniprot>`
- *      uses), must produce `hasData: true` from the example's own
- *      on-disk sample data. Local (`./`-prefixed) sources are read
- *      from disk for real, proving the shipped sample files actually
- *      parse through their real adapter; `https://` sources get an
- *      inert canned response (safe — `loadProtvistaData` catches
- *      per-track adapter failures rather than throwing, exactly as
- *      exercised in `load-data-baseline.spec.ts`).
+ *      uses), must produce `hasData: true`, AND every track the
+ *      example authored itself locally (`from: file` / `from:
+ *      inline` — as opposed to a `from: url` track riding on this
+ *      suite's canned `https://` fixture) must independently produce
+ *      non-empty data. The per-track check matters because
+ *      `hasData` is an OR across every track in the config — for
+ *      `extend-default/`, which inherits ~15 canned-fixture-backed
+ *      groups from the base config, `hasData` alone would stay true
+ *      even if its own `hotspots.csv` were empty or broken (the
+ *      per-track adapter call is try/caught, not thrown), silently
+ *      hiding exactly the regression this example exists to catch.
  *   3. Render smoke test — mounting a `<protvista-uniprot>` instance
- *      with that data must produce a populated group/track DOM,
- *      proving the shape `loadProtvistaData` produced is actually
- *      renderable, not just structurally valid.
+ *      with that data must produce a populated group/track DOM, and
+ *      each locally-authored track's own row must be among the
+ *      rendered nodes — proving the shape `loadProtvistaData`
+ *      produced for that specific track is actually renderable, not
+ *      just that *some* track rendered.
+ *
+ * A separate top-level `describe` block below pins the "default
+ * fetcher" contract that `extend-default/config.yaml`'s
+ * `extends: /src/default-config.yaml` relies on: `<protvista-uniprot>`
+ * never supplies a custom `extendsFetcher`, so that value must
+ * resolve correctly through the *library's own default* fetcher
+ * (bare `globalThis.fetch(url)`), not through any fs-based shim this
+ * suite constructs for its own convenience.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
 import { readdirSync, existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { resolve, dirname, join } from 'node:path';
@@ -46,6 +61,7 @@ const EXAMPLES_ROOT = resolve(
   dirname(fileURLToPath(import.meta.url)),
   '../../examples'
 );
+const REPO_ROOT = resolve(EXAMPLES_ROOT, '..');
 
 interface DiscoveredExample {
   name: string;
@@ -64,6 +80,27 @@ function discoverExamples(): DiscoveredExample[] {
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
+// The set of examples this suite is written to know about. Discovery
+// is dynamic (new directories are picked up automatically), but if
+// `examples/` ever ends up empty or `EXAMPLES_ROOT` drifts off the
+// real directory, `describe.each` below would silently register zero
+// tests and `vitest run` would still exit green. This assertion runs
+// independently of the loop and fails loudly in that scenario.
+it('discovers the expected example directories', () => {
+  const names = discoverExamples().map((e) => e.name);
+  expect(names).toEqual(
+    expect.arrayContaining([
+      'basic',
+      'inline-data',
+      'csv',
+      'tsv',
+      'json',
+      'bed',
+      'extend-default',
+    ])
+  );
+});
+
 /**
  * Canned response for any `https://`-style API source. Shaped like a
  * real UniProt features payload (`{ features: [...] }`) so the
@@ -79,9 +116,22 @@ const CANNED_FEATURES_RESPONSE = {
   features: [{ type: 'DOMAIN', begin: 1, end: 770, description: 'Fixture domain' }],
 };
 
+/**
+ * Resolve a local reference the way the *real* library resolves it
+ * once the value is origin-absolute: `/foo` means "relative to
+ * whatever root the hosting page is served from" (the repo root, for
+ * every deployment this suite cares about), not "relative to this
+ * particular example's own directory." Anything else stays
+ * example-directory-relative, matching a real page's `./`/`../`
+ * behaviour when the config file and its data live side by side.
+ */
+function resolveLocalRef(exampleDir: string, ref: string): string {
+  return ref.startsWith('/') ? join(REPO_ROOT, ref) : resolve(exampleDir, ref);
+}
+
 function makeExampleFetchers(exampleDir: string) {
   const extendsFetcher = async (ref: string): Promise<string> =>
-    readFile(resolve(exampleDir, ref), 'utf8');
+    readFile(resolveLocalRef(exampleDir, ref), 'utf8');
 
   const fetchOne = async (
     url: string,
@@ -90,7 +140,7 @@ function makeExampleFetchers(exampleDir: string) {
     if (/^https?:\/\//i.test(url)) {
       return responseType === 'json' ? CANNED_FEATURES_RESPONSE : '';
     }
-    const text = await readFile(resolve(exampleDir, url), 'utf8');
+    const text = await readFile(resolveLocalRef(exampleDir, url), 'utf8');
     return responseType === 'json' ? JSON.parse(text) : text;
   };
 
@@ -109,16 +159,55 @@ function buildInstance(overrides: Record<string, unknown>) {
   return el;
 }
 
+/**
+ * The tracks an example authored itself — `from: file` (a local
+ * `./x.csv`-style shorthand) or `from: inline` — as opposed to a
+ * `from: url` track whose data in this suite comes entirely from
+ * {@link CANNED_FEATURES_RESPONSE}. Used to assert each example's own
+ * sample data specifically, not just the aggregate `hasData` flag
+ * (which a canned-fixture-backed sibling track can satisfy on its
+ * own — see the file-level doc comment).
+ */
+function findLocalTracks(
+  config: NormalizedConfig
+): { groupId: string; trackId: string; key: string }[] {
+  const found: { groupId: string; trackId: string; key: string }[] = [];
+  for (const group of config.groups) {
+    for (const track of group.tracks) {
+      const from = track.data[0]?.from;
+      if (from === 'file' || from === 'inline') {
+        found.push({
+          groupId: group.id,
+          trackId: track.id,
+          key: `${group.id}-${track.id}`,
+        });
+      }
+    }
+  }
+  return found;
+}
+
 describe.each(discoverExamples())('example: $name', ({ dir, configPath }) => {
   let config: NormalizedConfig;
+  let result: Awaited<ReturnType<typeof loadProtvistaData>>;
 
   beforeAll(async () => {
     const text = await readFile(configPath, 'utf8');
-    const { extendsFetcher } = makeExampleFetchers(dir);
+    const { extendsFetcher, fetchOne } = makeExampleFetchers(dir);
     config = await loadConfig(text, {
       accession: REFERENCE_ACCESSION,
       extendsFetcher,
     });
+    // Loaded once and shared by every `it()` below — the config and
+    // its data pipeline are read-only from here on, and re-running
+    // `loadProtvistaData` per assertion bought nothing but CPU
+    // (worst for `extend-default/`, which fans out to ~15 tracks).
+    result = await loadProtvistaData(
+      REFERENCE_ACCESSION,
+      config,
+      fetchOne,
+      realAdapters as AdapterMap
+    );
   });
 
   it('validates against the schema', () => {
@@ -126,26 +215,28 @@ describe.each(discoverExamples())('example: $name', ({ dir, configPath }) => {
     expect(config.groups.length).toBeGreaterThan(0);
   });
 
-  it('loads real on-disk sample data through the real adapter map', async () => {
-    const { fetchOne } = makeExampleFetchers(dir);
-    const result = await loadProtvistaData(
-      REFERENCE_ACCESSION,
-      config,
-      fetchOne,
-      realAdapters as AdapterMap
-    );
+  it('produces data through the real adapter map, including every locally-authored track', () => {
+    // Coarse signal: at least one track anywhere produced data. For
+    // `basic/` this is entirely the canned `https://` fixture (it
+    // has no local file); for every other example it's backed by at
+    // least the sample data checked individually below.
     expect(result.hasData).toBe(true);
+
+    // Precise signal: each track the example itself owns (its own
+    // CSV/TSV/JSON/BED file, or inline data) must independently have
+    // parsed into a non-empty array — not merely "some sibling track
+    // in this config produced data."
+    for (const { key } of findLocalTracks(config)) {
+      const payload = result.data[key];
+      expect(Array.isArray(payload), `${key} should be an array`).toBe(true);
+      expect(
+        (payload as unknown[]).length,
+        `${key} should be non-empty`
+      ).toBeGreaterThan(0);
+    }
   });
 
-  it('smoke-renders at least one populated group', async () => {
-    const { fetchOne } = makeExampleFetchers(dir);
-    const result = await loadProtvistaData(
-      REFERENCE_ACCESSION,
-      config,
-      fetchOne,
-      realAdapters as AdapterMap
-    );
-
+  it('smoke-renders the example, including each locally-authored track', () => {
     const el = buildInstance({
       config,
       data: result.data,
@@ -160,13 +251,78 @@ describe.each(discoverExamples())('example: $name', ({ dir, configPath }) => {
     // the real template (see `hasRenderableData` gating in
     // `protvista-uniprot.ts`), so this doesn't assert every declared
     // group renders — just that the example's own data produced at
-    // least one real, populated group/track (the actual smoke-render
-    // guarantee).
+    // least one real, populated group/track.
     expect(
       target.querySelectorAll(`.${CSS_PREFIX}-group`).length
     ).toBeGreaterThan(0);
     expect(
       target.querySelectorAll(`.${CSS_PREFIX}-group__track`).length
     ).toBeGreaterThan(0);
+
+    // And, specifically, every track the example authored itself —
+    // not just "some" track anywhere in an inherited base config —
+    // rendered its own row.
+    for (const { trackId, key } of findLocalTracks(config)) {
+      const node = target.querySelector(`#${CSS_PREFIX}-track_${trackId}`);
+      expect(node, `#${CSS_PREFIX}-track_${trackId} (${key}) should render`).not.toBeNull();
+    }
+  });
+});
+
+/**
+ * `extend-default/config.yaml` declares `extends: /src/default-config.yaml`
+ * — an origin-absolute path chosen specifically because
+ * `<protvista-uniprot>` never passes a custom `extendsFetcher` to
+ * `loadConfig` (see `resolveViewerConfig()` in `protvista-uniprot.ts`);
+ * it always uses the library's default fetcher, bare
+ * `globalThis.fetch(url)`. The `describe.each` block above proves the
+ * example works under this suite's own fs-based `extendsFetcher`,
+ * which is convenient for CI but is NOT what a real embedder's page
+ * uses — so on its own it can't catch a regression to a path shape
+ * that only this suite's shim happens to tolerate.
+ *
+ * This block instead drives `loadConfig` with no `extendsFetcher` at
+ * all — exactly like the real element — and stubs `globalThis.fetch`
+ * to pin two things: the loader passes the `extends:` value through
+ * *verbatim* (no hidden resolution logic of our own to drift), and an
+ * origin-absolute value is what a same-origin page actually needs.
+ */
+describe('extend-default — default-fetcher semantics (no custom extendsFetcher, matches the real element)', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('resolves extends: /src/default-config.yaml via a bare globalThis.fetch(url) call', async () => {
+    const configText = await readFile(
+      join(EXAMPLES_ROOT, 'extend-default', 'config.yaml'),
+      'utf8'
+    );
+    const defaultConfigText = await readFile(
+      join(REPO_ROOT, 'src', 'default-config.yaml'),
+      'utf8'
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe('/src/default-config.yaml');
+      return {
+        ok: true,
+        text: async () => defaultConfigText,
+      } as Response;
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const config = await loadConfig(configText, {
+      accession: REFERENCE_ACCESSION,
+      // No `extendsFetcher` — pins the same code path
+      // `<protvista-uniprot>` exercises.
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('/src/default-config.yaml');
+    // The merge succeeded: the ~15 inherited base groups plus MY_LAB.
+    expect(config.groups.length).toBeGreaterThan(1);
+    expect(config.groups.some((g) => g.id === 'MY_LAB')).toBe(true);
   });
 });

--- a/src/load-data.ts
+++ b/src/load-data.ts
@@ -314,10 +314,12 @@ export async function loadProtvistaData(
     if (track.filterUI === 'nightingale-filter') {
       data[`${key}${UNFILTERED_SUFFIX}`] = payload;
     }
-    const adapter = track.data[0]?.adapter;
+    const source = track.data[0];
+    const isGenericFileAdapter =
+      source?.adapter !== undefined && GENERIC_FILE_ADAPTERS.has(source.adapter);
+    const isInline = source?.from === 'inline';
     if (
-      adapter !== undefined &&
-      GENERIC_FILE_ADAPTERS.has(adapter) &&
+      (isGenericFileAdapter || isInline) &&
       Array.isArray(payload) &&
       payload.length > 0
     ) {
@@ -374,6 +376,30 @@ export async function loadProtvistaData(
               return;
             }
             const transformedData: any = customTrackData[trackKey];
+            const filteredData =
+              Array.isArray(transformedData) && filter
+                ? transformedData.filter(
+                    ({ type }: { type?: string }) => type === filter
+                  )
+                : transformedData;
+            if (filteredData == null) return;
+            const spec: TooltipSpec | undefined =
+              dataTooltip ?? (kind ? tooltipDefaults[kind] : undefined);
+            const annotated = applyTooltipResolver(filteredData, spec, {
+              accession,
+              trackId,
+              kind: kind ?? '',
+            });
+            assignTrackData(trackKey, annotated, track);
+            return annotated;
+          }
+
+          // `from: inline` — the payload lives on the descriptor itself
+          // (`inlineData`, populated by the normalizer); no fetch, no
+          // adapter. Filter + tooltip resolution still apply, mirroring
+          // `from: custom` above.
+          if (first.from === 'inline') {
+            const transformedData: any = first.inlineData;
             const filteredData =
               Array.isArray(transformedData) && filter
                 ? transformedData.filter(

--- a/src/load-data.ts
+++ b/src/load-data.ts
@@ -327,6 +327,36 @@ export async function loadProtvistaData(
     }
   };
 
+  // Shared tail for `from: custom` and `from: inline` tracks: apply
+  // the track's `filter:` shortcut, resolve tooltips, and assign the
+  // result. The only difference between the two sources is where
+  // `transformedData` comes from — consumer-injected via
+  // `setTrackData()` vs. the descriptor's own `inlineData` — both
+  // skip the fetch + adapter step entirely.
+  const filterResolveAndAssign = (
+    transformedData: unknown,
+    trackKey: string,
+    track: NormalizedTrack
+  ): unknown => {
+    const { filter, kind, dataTooltip, id: trackId } = track;
+    const filteredData =
+      Array.isArray(transformedData) && filter
+        ? (transformedData as Array<{ type?: string }>).filter(
+            ({ type }) => type === filter
+          )
+        : transformedData;
+    if (filteredData == null) return undefined;
+    const spec: TooltipSpec | undefined =
+      dataTooltip ?? (kind ? tooltipDefaults[kind] : undefined);
+    const annotated = applyTooltipResolver(filteredData, spec, {
+      accession,
+      trackId,
+      kind: kind ?? '',
+    });
+    assignTrackData(trackKey, annotated, track);
+    return annotated;
+  };
+
   for (const group of config.groups) {
     const groupId = group.id;
     // A targeted retry only recomputes groups that own a reloaded track;
@@ -375,23 +405,11 @@ export async function loadProtvistaData(
               );
               return;
             }
-            const transformedData: any = customTrackData[trackKey];
-            const filteredData =
-              Array.isArray(transformedData) && filter
-                ? transformedData.filter(
-                    ({ type }: { type?: string }) => type === filter
-                  )
-                : transformedData;
-            if (filteredData == null) return;
-            const spec: TooltipSpec | undefined =
-              dataTooltip ?? (kind ? tooltipDefaults[kind] : undefined);
-            const annotated = applyTooltipResolver(filteredData, spec, {
-              accession,
-              trackId,
-              kind: kind ?? '',
-            });
-            assignTrackData(trackKey, annotated, track);
-            return annotated;
+            return filterResolveAndAssign(
+              customTrackData[trackKey],
+              trackKey,
+              track
+            );
           }
 
           // `from: inline` — the payload lives on the descriptor itself
@@ -399,23 +417,7 @@ export async function loadProtvistaData(
           // adapter. Filter + tooltip resolution still apply, mirroring
           // `from: custom` above.
           if (first.from === 'inline') {
-            const transformedData: any = first.inlineData;
-            const filteredData =
-              Array.isArray(transformedData) && filter
-                ? transformedData.filter(
-                    ({ type }: { type?: string }) => type === filter
-                  )
-                : transformedData;
-            if (filteredData == null) return;
-            const spec: TooltipSpec | undefined =
-              dataTooltip ?? (kind ? tooltipDefaults[kind] : undefined);
-            const annotated = applyTooltipResolver(filteredData, spec, {
-              accession,
-              trackId,
-              kind: kind ?? '',
-            });
-            assignTrackData(trackKey, annotated, track);
-            return annotated;
+            return filterResolveAndAssign(first.inlineData, trackKey, track);
           }
 
           const trackData = (Array.isArray(url) ? url : [url ?? '']).map(


### PR DESCRIPTION
## Purpose
Addresses #208 

## Approach

 New examples/ directory — seven self-contained, runnable configs: basic (URL-sourced), inline-data (from:
  inline), csv/tsv/json/bed (one generic-format adapter each), and extend-default (extends: the shipped
  UniProt default + a custom CSV track), plus examples/README.md explaining the layout and the accession:
  P05067 convention.

  CI validation — src/__spec__/examples.spec.ts dynamically discovers every examples/*/config.yaml, and for
  each one: validates it against the schema, runs it through the real data pipeline and adapter map
  (reading local sample files from disk for real), and smoke-renders a real <protvista-uniprot> instance to
  confirm populated group/track DOM. Runs automatically via the existing yarn test:unit CI step — no
  workflow changes needed.

  Bug fix (src/load-data.ts) — while wiring up the inline-data example, found that from: inline tracks were
  validated/normalized but never actually read by loadProtvistaData (it fell through to the URL-fetch
  branch and produced garbage). Added a dedicated branch mirroring the existing from: custom handling, and
  extended the hasData gate to recognize non-empty inline payloads.

## Testing

All tests verified

## Visual changes

add screenshots/recordings if applicable

## Checklist

- [x] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed by all interested parties.
