### PR TITLE
Document React host integration pattern for tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Reactive properties on the `<protvista-uniprot>` element (HTML attribute name in
 - `configSrc` [`config-src`]: `string` — URL or file path to a YAML or JSON config. Fetched and parsed at mount time. See [Configuration](#configuration).
 - `config`: `ProtvistaViewerConfig` — a parsed config object, assigned as a JS property. Alternative to `config-src` when the embedder already has the config in memory.
 - `nostructure` [`nostructure`]: `boolean` (default `false`) — suppresses the PDBe 3D structure group.
-- `notooltip` [`notooltip`]: `boolean` (default `false`) — suppresses the built-in click tooltip. Typically set by embedders rendering their own overlay.
+- `notooltip` [`notooltip`]: `boolean` (default `false`) — suppresses the built-in click tooltip. Typically set by embedders rendering their own overlay. See [React host integration](./docs/react-integration.md) for the consumer-side pattern.
 - `suspend` [`suspend`]: `boolean` (default `false`) — pauses rendering. Useful when the accession is about to change and you want to avoid a flash of intermediate state.
 
 ## Development
@@ -178,6 +178,7 @@ The viewer renders a single collapsible group "Domains" (label title-cased from 
 - **Schema reference.** [`specs/config-approach.md`](./specs/config-approach.md) documents every field (`groups`, `tracks`, `sources`, `defaults`, `extends`, `kind`, `data`, `rendering`, `dataTooltip`) with worked examples and edge-case semantics. This is the normative source.
 - **Canonical default.** [`src/default-config.yaml`](./src/default-config.yaml) is the UniProt viewer itself, authored in the new schema. Useful as a reference.
 - **Authoring `dataTooltip`.** [`docs/data-tooltip.md`](./docs/data-tooltip.md) covers the three authoring forms (bare string, `kind: fields`, `kind: markdown`) with examples.
+- **React host integration.** [`docs/react-integration.md`](./docs/react-integration.md) shows how a React host owns its own rich tooltips via the `change` event + `notooltip`, with a minimal worked example. The normative contract is [`specs/config-approach.md`](./specs/config-approach.md#react-host-integration).
 
 ## Events
 

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -1,0 +1,122 @@
+# React host integration
+
+When you need a tooltip the config can't express — a React component, evidence badges, taxonomy lookups, links into your app's own routing, or any stateful UI — you own it in the host. The library hands you an event; you render the overlay.
+
+There are exactly two paths for the per-datapoint tooltip, and nothing in between:
+
+- **Declarative (library renders it).** Author `dataTooltip` in YAML and let the built-in click popover render it. Pick this whenever it's enough — see [`data-tooltip.md`](./data-tooltip.md).
+- **Consumer-owned (you render it).** Set `notooltip` on the element, listen for the `change` event, and mount your own overlay. This page walks through that path.
+
+The normative contract for everything below lives in [`specs/config-approach.md`](../specs/config-approach.md#react-host-integration); this page is the tutorial.
+
+## The shape of it
+
+1. **Set `notooltip`** so the built-in popover stays out of your way.
+2. **Attach a `change` listener** to the `<protvista-uniprot>` element.
+3. **Branch on `detail.eventType`** — `click` opens a tooltip; `mouseover` / `mouseout` drive hover; `reset` (scroll/zoom) dismisses.
+4. **Read `detail.feature`** (the full datapoint, including any library-precomputed `tooltipContent`) and **`detail.coords`** (an `[x, y]` page-coordinate tuple).
+5. **Render your overlay** at those coordinates and **dismiss** on the `{ undefined, 'reset', 'click' }` set.
+
+### `notooltip` does not hide the content
+
+`notooltip` only disables the built-in popover's DOM mount. The library still resolves each item's `tooltipContent` during data loading, so you can read `detail.feature.tooltipContent` off the event even with `notooltip` set — handy if you want the library's pre-rendered declarative string inside your own overlay chrome.
+
+### `eventType` vocabulary
+
+| `eventType`  | User action            | What to do                                                    |
+| ------------ | ---------------------- | ------------------------------------------------------------- |
+| `'click'`    | Clicked a feature      | Open (or replace) the tooltip                                 |
+| `'mouseover'`| Hover enter            | Drive hover state, if you want hover tooltips                 |
+| `'mouseout'` | Hover leave            | Clear hover state                                             |
+| `'reset'`    | Scrolled / zoomed view | Dismiss — "stop showing any per-feature tooltip"              |
+
+These `eventType` values, and the interactions that trigger them, are emitted by the underlying Nightingale track (`@nightingale-elements`), not by `<protvista-uniprot>` itself — Nightingale emits `'reset'` on view changes such as scroll and zoom. The viewer only re-exposes the payload on its `change` event.
+
+uniprot-website dismisses on `hideTooltipEvents = new Set([undefined, 'reset', 'click'])`: a bare event (no `eventType`), a `reset`, and a fresh `click` all hide the current overlay — the `click` then re-opens for the newly clicked feature.
+
+### `coords` is in page coordinates
+
+`detail.coords` is `[x, y]` in **page coordinates** (`pageX` / `pageY` — viewport-relative plus the page scroll offset). To anchor a `position: fixed` overlay to the viewport, subtract `window.scrollX` / `window.scrollY`, the same transform the built-in popover applies. If you render into a container that already lives in page-coordinate space (an absolutely-positioned layer), use the tuple unchanged.
+
+## A minimal example
+
+React + [Floating UI](https://floating-ui.com/) only. The example imports from `@floating-ui/react`, which is a separate install from the `@floating-ui/dom` the viewer already bundles (`npm i @floating-ui/react`) — or drop Floating UI entirely and position an absolutely-placed `<div>` yourself. Set `notooltip` on the element; the effect wires one `change` listener and positions a fixed overlay at the (viewport-adjusted) click point.
+
+```tsx
+import { useEffect, useRef, useState } from 'react';
+import { useFloating, autoUpdate } from '@floating-ui/react';
+
+type ChangeDetail = {
+  eventType?: 'click' | 'mouseover' | 'mouseout' | 'reset';
+  feature?: { tooltipContent?: string; [k: string]: unknown };
+  coords?: [number, number];
+};
+
+const HIDE = new Set([undefined, 'reset', 'click']);
+
+export function FeatureViewer({ accession }: { accession: string }) {
+  const hostRef = useRef<HTMLElement>(null);
+  const [tip, setTip] = useState<{ html: string } | null>(null);
+  // whileElementsMounted: autoUpdate keeps the overlay positioned and avoids a
+  // first-frame top-left flash before the async placement resolves.
+  const { refs, floatingStyles } = useFloating({ strategy: 'fixed', whileElementsMounted: autoUpdate });
+
+  useEffect(() => {
+    const el = hostRef.current;
+    if (!el) return;
+    const onChange = (e: Event) => {
+      const { eventType, feature, coords } = (e as CustomEvent<ChangeDetail>).detail ?? {};
+      if (HIDE.has(eventType)) setTip(null); // reset/undefined dismiss; click falls through to re-open
+      // This example reuses the library's precomputed tooltipContent. To build
+      // your own UI from feature fields (evidence badges, links, …), branch on
+      // `feature` here instead of gating on `feature.tooltipContent`.
+      if (eventType !== 'click' || !coords || !feature?.tooltipContent) return;
+      const [x, y] = coords; // page coords → viewport for position: fixed
+      refs.setPositionReference({
+        getBoundingClientRect: () =>
+          ({ x: x - window.scrollX, y: y - window.scrollY,
+             top: y - window.scrollY, left: x - window.scrollX,
+             right: x - window.scrollX, bottom: y - window.scrollY,
+             width: 0, height: 0 }) as DOMRect,
+      });
+      setTip({ html: feature.tooltipContent });
+    };
+    el.addEventListener('change', onChange);
+    return () => el.removeEventListener('change', onChange);
+  }, [refs]);
+
+  return (
+    <>
+      {/* @ts-expect-error custom element */}
+      <protvista-uniprot ref={hostRef} accession={accession} notooltip />
+      {tip && (
+        <div ref={refs.setFloating} style={floatingStyles} role="tooltip"
+             dangerouslySetInnerHTML={{ __html: tip.html }} />
+      )}
+    </>
+  );
+}
+```
+
+A note on that `dangerouslySetInnerHTML`: the library already HTML-escapes field values and passes declarative `tooltipContent` through Markdoc's safe renderer, so the pre-rendered string is safe to inject. Any HTML *you* assemble in the host — from your own data, template strings, or third-party sources — is your responsibility to sanitize.
+
+The real reference is uniprot-website's `FeatureViewer.tsx`; this is the same pattern with the ambient app concerns stripped out.
+
+## React 19: prefer the ref callback
+
+React 19 lets a ref callback return its own cleanup, which folds the listener's mount and unmount into one place and drops the `useEffect` (and its dependency bookkeeping):
+
+```tsx
+const hostRef = (el: HTMLElement | null) => {
+  if (!el) return;
+  const onChange = (e: Event) => { /* …as above… */ };
+  el.addEventListener('change', onChange);
+  return () => el.removeEventListener('change', onChange);
+};
+
+// …
+{/* @ts-expect-error custom element */}
+<protvista-uniprot ref={hostRef} accession={accession} notooltip />
+```
+
+Prefer this once you're on React 19 — don't copy the split mount/unmount `useEffect` shape as the canonical form.

--- a/specs/config-approach.md
+++ b/specs/config-approach.md
@@ -868,6 +868,49 @@ Accessibility is a grant-level commitment (see the OMP) and is baked into the sc
 - **Sensible out-of-the-box fallback.** Tooltip precedence is: non-empty `item.tooltipContent` supplied by an adapter, then `track.dataTooltip`, then `tooltipDefaults[kind]`, then auto-fallback. When the auto-fallback runs, it renders through Markdoc and emits at most ten rows in this order: `type`, `description`, position (`start | begin` plus `end`, collapsed to `Position` when equal), variant sequence (`wildType` plus `alternativeSequence | variant`), `consequenceType`, `clinicalSignificances`, `score`, `xrefs`, `evidences`, then remaining top-level scalar fields such as values added by `calculate` transforms. Missing fields drop out; an item carrying none of them stays empty. Xrefs become links only when the entry carries a URL that passes the tooltip URL allowlist (`http:`, `https:`, `mailto:`, or relative URL forms).
 - **No colour-only encoding.** `RenderingOptions.shape` exists partly so tracks can encode distinctions redundantly (e.g. shape _and_ colour) rather than colour alone. Config authors building custom tracks are encouraged to use shape or label text as a secondary channel alongside colour.
 
+## React host integration
+
+Rich, stateful, product-specific tooltips (evidence icons, taxonomy lookups, cross-links into an app's own routing, React components) are not a config concern. The library offers exactly two paths for the per-datapoint tooltip surface, and there is no in-between — no programmatic per-`kind` override registry ships:
+
+1. **Declarative tooltips (library-owned).** Authored in YAML as `dataTooltip` (`kind: fields` or `kind: markdown`, or the bare-string shorthand) and rendered by the library's built-in Floating-UI click popover. See [`docs/data-tooltip.md`](../docs/data-tooltip.md).
+2. **Consumer-owned tooltips (host-owned).** The React host sets `notooltip` on the element, listens for the Nightingale `change` event, and renders its own overlay at the reported coordinates. This is the canonical path for React adopters and the contract is normative below.
+
+A tutorial-flavoured walkthrough with a copy-pasteable minimal example lives at [`docs/react-integration.md`](../docs/react-integration.md); this section is the normative contract.
+
+### The `notooltip` attribute
+
+`notooltip` (boolean attribute, JS property `notooltip`, default `false`) disables the built-in popover's DOM mount — the library's click-tooltip controller stays quiet and never appends its `<div role="tooltip">` to the light DOM. A React host that renders its own overlay always wants `notooltip` set, so the two tooltip surfaces don't both appear on a click.
+
+`notooltip` does **not** suppress `feature.tooltipContent` resolution. The tooltip-content pipeline runs during data loading regardless of the attribute, so the pre-rendered declarative HTML string is still attached to each item and is still readable off the `change` event (`detail.feature.tooltipContent`). A consumer that wants the library's declarative string — but rendered inside its own overlay chrome — can set `notooltip` and read `tooltipContent` straight off the event.
+
+### The `change` event contract
+
+Attach a `change` listener to the `<protvista-uniprot>` element. Its `detail` carries:
+
+- **`eventType`** — one of `'click'`, `'mouseover'`, `'mouseout'`, `'reset'`, emitted by the underlying Nightingale track (`@nightingale-elements`) and re-exposed on the viewer's `change` event. This vocabulary is load-bearing:
+  - `'click'` — the user clicked a feature. Open (or replace) your tooltip.
+  - `'mouseover'` / `'mouseout'` — hover enter/leave over a feature. Drive host hover state if you want hover tooltips; ignore otherwise.
+  - `'reset'` — Nightingale emits this when the user scrolls or zooms the view, meaning "stop showing any per-feature tooltip." Treat it as a dismissal.
+
+  uniprot-website encodes the dismissal set as `hideTooltipEvents = new Set([undefined, 'reset', 'click'])` — a bare event with no `eventType` (`undefined`), a `reset`, and a fresh `click` all dismiss the current overlay (the `click` then re-opens for the newly clicked feature). Everything else is a hover signal.
+- **`feature`** — the full adapter-output item for the interacted datapoint, including any `tooltipContent` the library pre-computed.
+- **`coords`** — an `[x, y]` tuple in **page coordinates** (`pageX`/`pageY` — viewport-relative *plus* the current scroll offset). To position against the viewport (what Floating UI and `position: fixed` expect), subtract `window.scrollX` / `window.scrollY`, exactly as the built-in popover does. If you instead render into an absolutely-positioned container that already lives in page-coordinate space, use `[x, y]` unchanged.
+
+The `change` payload (`eventType`, `feature`, `coords`) is part of the viewer's stable compatibility surface — see [`docs/architecture-audit.md`](../docs/architecture-audit.md).
+
+### Rendering the overlay
+
+The host owns the overlay entirely — JSX, lifecycle, and styling. Render it into a portal or a Floating-UI-positioned `<div>` anchored at `coords`, show it on `click`, and hide it on the `{undefined, 'reset', 'click'}` dismissal set above. The library contributes only the event and the (optional) pre-rendered `tooltipContent`.
+
+Two interaction edge cases worth knowing:
+
+- **Collapsed group aggregates.** A click on a collapsed group's aggregate track opens a tooltip *without* a highlight state change — distinct from a click on an expanded detail track, which also toggles the highlight. Hosts that key any behaviour off the highlight should not assume every tooltip-opening click carries one.
+- **Bring-your-own-data kinds.** Consumers pairing generic semantic kinds (e.g. `linegraph`) with a React host are a primary audience for this pattern — the event contract is identical regardless of `kind`.
+
+### React 19 note
+
+The mount/unmount of the `change` listener is naturally expressed as a single ref callback that returns its cleanup function (React 19). Prefer that shape over the older split-`useEffect` mount/unmount pair; new adopters should not copy the split form as canonical. The worked example in [`docs/react-integration.md`](../docs/react-integration.md) shows both.
+
 ## Security and trust model
 
 The viewer runs in the embedder's browsing context and inherits the embedder's CSP and same-origin policy. The schema does not introduce new privilege — it only declaratively names the network destinations the viewer will fetch.

--- a/src/protvista-uniprot.ts
+++ b/src/protvista-uniprot.ts
@@ -192,7 +192,11 @@ let protvistaInstanceSeq = 0;
 class ProtvistaUniprot extends LitElement {
   private openGroups: string[];
   private nostructure: boolean;
-  /** Opt out of the built-in click tooltip. Consumers rendering a React overlay typically set this. */
+  /**
+   * Opt out of the built-in click tooltip. Consumers rendering a React overlay typically set this.
+   * @see specs/config-approach.md "React host integration" (and docs/react-integration.md) for the
+   * `change`-event listener pattern React hosts pair with this attribute.
+   */
   private notooltip?: boolean;
   private hasData: boolean;
   private loading: boolean;


### PR DESCRIPTION
## Purpose

`<protvista-uniprot>` is a light-DOM Web Component consumed by React hosts (most prominently
uniprot-website). The production-proven React integration pattern — set `notooltip`, listen for
the `change` event, read `detail.feature.tooltipContent` + `detail.coords`, and render a
host-owned overlay at those coordinates — works today but was **nowhere documented in this repo**.
A new React adopter had to reverse-engineer it from consumer code (uniprot-website's
`FeatureViewer.tsx`), where the event shape, the `notooltip` attribute, and the dismissal
vocabulary are all load-bearing yet undiscoverable from the viewer's own types or README.

This PR codifies that pattern as the canonical path for React hosts.

## Approach

- **`specs/config-approach.md`** — new normative `## React host integration` section (placed
  before `## Security and trust model`). Covers: the declarative-vs-consumer split (no in-between
  registry); `notooltip` semantics (disables the built-in popover's DOM mount only, and does
  **not** suppress `tooltipContent` resolution); the full `change`-event contract — the
  `eventType` vocabulary (`click` / `mouseover` / `mouseout` / `reset`, emitted by the underlying
  Nightingale track and re-exposed on the viewer's event), `detail.feature`, and `detail.coords`
  as page coordinates with the `window.scrollX/Y` transform; overlay rendering and the
  `{ undefined, 'reset', 'click' }` dismissal set; a React 19 ref-callback-with-cleanup note; and
  cross-references to the collapsed-aggregate click and generic `linegraph` BYOD cases.
- **`docs/react-integration.md`** — new tutorial-flavoured companion (mirrors
  `docs/data-tooltip.md`), with a ~30-line worked React + Floating UI example and the React 19
  variant. Defers to the spec as the normative contract.
- **`README.md`** — the `notooltip` API row and the "Learning more" list gain cross-links to the
  new doc and the spec section.
- **`src/protvista-uniprot.ts`** — the `notooltip` property JSDoc gains a one-line `@see` pointer
  (comment-only; no behaviour change).

## Testing

None

## Visual changes

None

## Checklist

- [x] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] If needed, the changes have been previewed by all interested parties.