### PR TITLE
malformed top-level entries now get one targeted error

### DIFF
--- a/src/schema/__spec__/validate.spec.ts
+++ b/src/schema/__spec__/validate.spec.ts
@@ -722,6 +722,18 @@ describe('validateConfig — invalid top-level entry shape', () => {
     expect(result.issues[0].message).toContain('at index 0');
   });
 
+  it('falls back to the index for a non-string or empty id', () => {
+    // The guard is `typeof id === 'string' && id.length > 0`. A numeric
+    // or blank id is not a usable label, so it must degrade to the
+    // index rather than quote `'42'` / `''` into the message.
+    for (const id of [42, ''] as const) {
+      const result = validateConfig(withEntry({ id, kind: 'features' }), freshRegistry());
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0].message).toContain('at index 0');
+      expect(result.issues[0].message).not.toContain(`'${id}'`);
+    }
+  });
+
   it('treats an empty `tracks:` stub as unset, not as a group', () => {
     // `tracks:` with nothing after it parses to null. Consistent with
     // `rows-alias.ts`, that is a leftover stub rather than a value — so
@@ -731,6 +743,22 @@ describe('validateConfig — invalid top-level entry shape', () => {
     expect(result.issues).toHaveLength(1);
     expect(result.issues[0].code).toBe('invalid-entry-shape');
     expect(result.issues[0].message).toContain('neither');
+  });
+
+  it('reads a both-null stub as "neither", not "both"', () => {
+    // Both keys present but both empty (`tracks:` / `data:` with nothing
+    // after them) is the case that separates the `null == unset` rule
+    // from a plain key-existence check: by presence it looks like "both",
+    // but neither carries a value, so it must read as "neither".
+    const result = validateConfig(
+      withEntry({ id: 'blank', tracks: null, data: null }),
+      freshRegistry()
+    );
+
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].code).toBe('invalid-entry-shape');
+    expect(result.issues[0].message).toContain('neither');
+    expect(result.issues[0].message).not.toContain('both');
   });
 
   it('reports one issue per offending entry', () => {
@@ -761,9 +789,13 @@ describe('validateConfig — invalid top-level entry shape', () => {
   });
 
   it('still reports unrelated structural errors elsewhere in the config', () => {
-    // The suppression is scoped to the offending entry. A malformed
-    // entry must not hide a problem the author would otherwise have to
-    // discover on a second pass.
+    // The suppression is scoped to the offending entry: only the Ajv
+    // errors *under that entry* are dropped, so a structural problem
+    // elsewhere still surfaces on the same pass. (The subsequent
+    // semantic pass is skipped whenever any entry is flagged — that is
+    // the validator's existing short-circuit contract, not this
+    // suppression: a structural failure has always deferred semantic
+    // checks to a second run.)
     const result = validateConfig(
       {
         version: 'bogus',

--- a/src/schema/__spec__/validate.spec.ts
+++ b/src/schema/__spec__/validate.spec.ts
@@ -655,6 +655,172 @@ describe('validateConfig — accession placeholders', () => {
 });
 
 // ─────────────────────────────────────────────────────────────
+// Structural: malformed top-level entry shape
+// ─────────────────────────────────────────────────────────────
+
+describe('validateConfig — invalid top-level entry shape', () => {
+  /** Build a config whose single entry is `entry`. */
+  const withEntry = (entry: unknown) =>
+    ({
+      sources: { features: 'https://example.org/features' },
+      rows: [entry],
+    }) as unknown as ProtvistaViewerConfig;
+
+  it('flags an entry with neither `tracks:` nor `data:`, naming both fields', () => {
+    const result = validateConfig(
+      withEntry({ id: 'orphan', kind: 'features' }),
+      freshRegistry()
+    );
+
+    expect(result.valid).toBe(false);
+    // Exactly one issue: the whole point is that the contradictory
+    // "needs tracks" / "needs data" / `oneOf` trio no longer surfaces.
+    expect(result.issues).toHaveLength(1);
+    const [issue] = result.issues;
+    expect(issue.code).toBe('invalid-entry-shape');
+    expect(issue.path).toBe('/rows/0');
+    expect(issue.message).toContain("'orphan'");
+    expect(issue.message).toContain("'tracks:'");
+    expect(issue.message).toContain("'data:'");
+  });
+
+  it('flags an entry with both `tracks:` and `data:`, naming both fields', () => {
+    const result = validateConfig(
+      withEntry({ id: 'mixed', tracks: [], data: 'features' }),
+      freshRegistry()
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toHaveLength(1);
+    const [issue] = result.issues;
+    expect(issue.code).toBe('invalid-entry-shape');
+    expect(issue.message).toContain("'mixed'");
+    expect(issue.message).toContain("'tracks:'");
+    expect(issue.message).toContain("'data:'");
+    // The two cases must not read identically — this one is about
+    // having both, not about missing one.
+    expect(issue.message).toContain('both');
+  });
+
+  it('no longer surfaces the raw oneOf / contradictory required errors', () => {
+    const result = validateConfig(
+      withEntry({ id: 'orphan', kind: 'features' }),
+      freshRegistry()
+    );
+
+    const text = result.issues.map((i) => i.message).join('\n');
+    expect(text).not.toContain('oneOf');
+    expect(text).not.toContain("required property 'tracks'");
+    expect(text).not.toContain("required property 'data'");
+    expect(issueByCode(result.issues, 'schema')).toBeUndefined();
+  });
+
+  it('falls back to the index when the entry has no usable id', () => {
+    const result = validateConfig(withEntry({ kind: 'features' }), freshRegistry());
+
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].message).toContain('at index 0');
+  });
+
+  it('treats an empty `tracks:` stub as unset, not as a group', () => {
+    // `tracks:` with nothing after it parses to null. Consistent with
+    // `rows-alias.ts`, that is a leftover stub rather than a value — so
+    // the entry reads as "neither", not as an empty group.
+    const result = validateConfig(withEntry({ id: 'stub', tracks: null }), freshRegistry());
+
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].code).toBe('invalid-entry-shape');
+    expect(result.issues[0].message).toContain('neither');
+  });
+
+  it('reports one issue per offending entry', () => {
+    const result = validateConfig(
+      {
+        sources: { features: 'https://example.org/features' },
+        rows: [
+          { id: 'orphan' },
+          { id: 'mixed', tracks: [], data: 'features' },
+        ],
+      } as unknown as ProtvistaViewerConfig,
+      freshRegistry()
+    );
+
+    const shapeIssues = result.issues.filter(
+      (i) => i.code === 'invalid-entry-shape'
+    );
+    expect(shapeIssues).toHaveLength(2);
+    expect(shapeIssues.map((i) => i.path)).toEqual(['/rows/0', '/rows/1']);
+  });
+
+  it('leaves a non-object entry to the schema — it is not an ambiguous shape', () => {
+    const result = validateConfig(withEntry('not-an-entry'), freshRegistry());
+
+    expect(result.valid).toBe(false);
+    expect(issueByCode(result.issues, 'invalid-entry-shape')).toBeUndefined();
+    expect(issueByCode(result.issues, 'schema')).toBeDefined();
+  });
+
+  it('still reports unrelated structural errors elsewhere in the config', () => {
+    // The suppression is scoped to the offending entry. A malformed
+    // entry must not hide a problem the author would otherwise have to
+    // discover on a second pass.
+    const result = validateConfig(
+      {
+        version: 'bogus',
+        sources: { features: 'https://example.org/features' },
+        rows: [{ id: 'orphan', kind: 'features' }],
+      } as unknown as ProtvistaViewerConfig,
+      freshRegistry()
+    );
+
+    expect(issueByCode(result.issues, 'invalid-entry-shape')).toBeDefined();
+    const schemaIssue = issueByCode(result.issues, 'schema');
+    expect(schemaIssue).toBeDefined();
+    expect(schemaIssue!.path).toBe('/version');
+  });
+
+  it('suppresses only the flagged entry, not a similarly-prefixed sibling', () => {
+    // Guards the descendant test in `isUnderFlaggedEntry`: a flagged
+    // `/rows/1` must not swallow errors under `/rows/10`.
+    const rows: unknown[] = Array.from({ length: 11 }, (_, i) => ({
+      id: `g${i}`,
+      tracks: [{ id: 't', kind: 'features', data: 'features' }],
+    }));
+    rows[1] = { id: 'orphan' }; // flagged → /rows/1
+    rows[10] = { id: 'g10', tracks: [{ id: 't' }] }; // nested error → /rows/10/tracks/0
+
+    const result = validateConfig(
+      {
+        sources: { features: 'https://example.org/features' },
+        rows,
+      } as unknown as ProtvistaViewerConfig,
+      freshRegistry()
+    );
+
+    expect(issueByCode(result.issues, 'invalid-entry-shape')?.path).toBe('/rows/1');
+    expect(
+      result.issues.some((i) => i.path.startsWith('/rows/10/'))
+    ).toBe(true);
+  });
+
+  it('leaves valid groups and standalone tracks untouched', () => {
+    const result = validateConfig(
+      {
+        sources: { features: 'https://example.org/features' },
+        rows: [
+          { id: 'GROUP', tracks: [{ id: 't', kind: 'features', data: 'features' }] },
+          { id: 'standalone', kind: 'features', data: 'features' },
+        ],
+      } as unknown as ProtvistaViewerConfig,
+      freshRegistry()
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────
 

--- a/src/schema/errors.ts
+++ b/src/schema/errors.ts
@@ -53,6 +53,14 @@ export type ValidationIssueCode =
   | 'missing-accession'
   /** The config sets both `rows:` and its deprecated `groups:` alias. */
   | 'rows-alias-conflict'
+  /**
+   * A top-level `rows:` entry is neither a group nor a standalone track:
+   * it carries neither `tracks:` nor `data:`, or it carries both. The
+   * `oneOf` in the schema can only report this as a contradictory
+   * "needs `tracks`" / "needs `data`" pair, so the validator detects it
+   * directly and replaces those with one targeted message.
+   */
+  | 'invalid-entry-shape'
   // ── Extends resolution ─────────────────────────────────
   /** The `extends` chain forms a cycle (a → b → a). */
   | 'circular-extends'

--- a/src/schema/rows-alias.ts
+++ b/src/schema/rows-alias.ts
@@ -22,6 +22,7 @@
  */
 
 import { ConfigValidationError, type ValidationIssue } from './errors';
+import { isPlainObject, isSet } from './shape';
 
 /**
  * Author-facing text for the both-fields-set case. Exported so the
@@ -50,27 +51,6 @@ function warnOnce(): void {
 }
 
 /**
- * A plain (non-array, non-null) object — the only shape that can carry
- * either field. Anything else passes through untouched; the validator
- * surfaces a readable schema error for it.
- */
-function isConfigObject(v: unknown): v is Record<string, unknown> {
-  return v !== null && typeof v === 'object' && !Array.isArray(v);
-}
-
-/**
- * Whether a field was actually set by the author. An empty YAML key
- * (`groups:` / `rows:` with nothing after it) parses to `null` — a
- * leftover stub, not a value — so `null` counts as unset alongside
- * `undefined`. Deciding presence by key existence instead would reject a
- * blank `groups:` line (common right after a rename) as a both-fields
- * conflict and fire the deprecation warning for a field carrying nothing.
- */
-function isSet(v: unknown): boolean {
-  return v !== undefined && v !== null;
-}
-
-/**
  * Non-throwing probe for the both-fields-set case, returning the issue
  * rather than raising it.
  *
@@ -79,7 +59,7 @@ function isSet(v: unknown): boolean {
  * probes with this first and pushes the issue onto its own list.
  */
 export function rowsAliasConflict(config: unknown): ValidationIssue | undefined {
-  if (!isConfigObject(config)) return undefined;
+  if (!isPlainObject(config)) return undefined;
   if (!isSet(config.rows) || !isSet(config.groups)) return undefined;
   return {
     path: '/groups',
@@ -105,7 +85,7 @@ export function rowsAliasConflict(config: unknown): ValidationIssue | undefined 
  *   has given no way to tell which they meant.
  */
 export function resolveRowsAlias<T>(config: T): T {
-  if (!isConfigObject(config)) return config;
+  if (!isPlainObject(config)) return config;
   if (!('groups' in config)) return config;
 
   const conflict = rowsAliasConflict(config);

--- a/src/schema/shape.ts
+++ b/src/schema/shape.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared shape predicates for the schema layer.
+ *
+ * `rows-alias.ts` and `validate.ts` both need to answer the same two
+ * questions before Ajv runs — "is this a plain object that could carry a
+ * field?" and "did the author actually set this field?" — and both had
+ * their own copy. The copies were byte-identical and their doc comments
+ * asserted a single shared notion ("one notion of 'set' across the schema
+ * layer"), so they belong in one place where they cannot drift.
+ */
+
+/**
+ * A plain (non-null, non-array) object — the only shape that can carry a
+ * named field like `rows:`, `groups:`, `tracks:`, or `data:`. Anything
+ * else (a bare string, a number, `null`, an array) passes through
+ * untouched; the validator surfaces a readable schema error for it.
+ */
+export function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Whether a field was actually set by the author. An empty YAML key
+ * (`tracks:` / `rows:` / `groups:` with nothing after it) parses to
+ * `null` — a leftover stub, not a value — so `null` counts as unset
+ * alongside `undefined`. Deciding presence by key existence instead
+ * would treat a blank line (common right after a rename) as a real
+ * value: rejecting it as a both-fields conflict, firing the deprecation
+ * warning for a field carrying nothing, or reading a bare `tracks:` as
+ * an empty group.
+ */
+export function isSet(v: unknown): boolean {
+  return v !== undefined && v !== null;
+}

--- a/src/schema/validate.ts
+++ b/src/schema/validate.ts
@@ -50,6 +50,7 @@ import { isGroupConfig } from './discriminate';
 import type { Registry } from './registry';
 import { RENDERABLE_COMPONENT_NAMES } from './components';
 import { resolveRowsAlias, rowsAliasConflict } from './rows-alias';
+import { isPlainObject, isSet } from './shape';
 import { dataFileFormatForPath } from './file-formats';
 import type {
   ValidationIssue,
@@ -236,7 +237,13 @@ function checkEntryShapes(config: unknown): {
 
     const hasTracks = isSet(entry.tracks);
     const hasData = isSet(entry.data);
-    // Exactly one present is a well-formed entry — nothing to say.
+    // Exactly one present is a well-formed *shape* — nothing to say here.
+    // The probe deliberately keys on presence, not correctness: a
+    // present-but-malformed field (`tracks: 'oops'`, a non-object
+    // `data:`) has an unambiguous shape, so it falls through to Ajv,
+    // whose type/enum error names the actual mistake. Only the
+    // genuinely ambiguous neither/both cases — where Ajv can offer no
+    // better than the `oneOf` dump — are claimed below.
     if (hasTracks !== hasData) return;
 
     flagged.push(`/rows/${index}`);
@@ -269,22 +276,6 @@ function isUnderFlaggedEntry(instancePath: string, flagged: string[]): boolean {
 function describeEntry(entry: Record<string, unknown>, index: number): string {
   const { id } = entry;
   return typeof id === 'string' && id.length > 0 ? `'${id}'` : `at index ${index}`;
-}
-
-/** A plain (non-null, non-array) object — the only shape an entry can be. */
-function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return v !== null && typeof v === 'object' && !Array.isArray(v);
-}
-
-/**
- * Whether a field was actually set by the author. An empty YAML key
- * (`tracks:` with nothing after it) parses to `null` — a leftover stub,
- * not a value — so `null` counts as unset alongside `undefined`. Matches
- * `rows-alias.ts`, which treats an empty `rows:` / `groups:` stub the
- * same way: one notion of "set" across the schema layer.
- */
-function isSet(v: unknown): boolean {
-  return v !== undefined && v !== null;
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/src/schema/validate.ts
+++ b/src/schema/validate.ts
@@ -124,13 +124,26 @@ export function validateConfig(
   if (conflict) return { valid: false, issues: [conflict] };
   const resolved = resolveRowsAlias(config);
 
+  // ── Entry-shape probe ─────────────────────────────────────
+  // Run before Ajv so the entries it explains can have their `oneOf`
+  // fallout dropped below. See `checkEntryShapes`.
+  const shape = checkEntryShapes(resolved);
+
   // ── Structural pass ───────────────────────────────────────
   const structural = getStructuralValidator();
   const ok = structural(resolved);
-  if (!ok) {
+  if (!ok || shape.issues.length > 0) {
     for (const err of structural.errors ?? []) {
+      // Suppress every Ajv error belonging to an entry the probe already
+      // explained: for those, Ajv can only produce the contradictory
+      // "needs `tracks`" / "needs `data`" pair plus the `oneOf` dump, and
+      // the targeted issue says the same thing once, in the author's
+      // vocabulary. Errors elsewhere in the config are untouched, so a
+      // malformed entry never hides an unrelated problem.
+      if (isUnderFlaggedEntry(err.instancePath, shape.flagged)) continue;
       issues.push(ajvErrorToIssue(err));
     }
+    issues.push(...shape.issues);
     // Semantic checks would walk into `undefined` fields, producing
     // spurious errors. Stop here and let the caller fix structural
     // problems first.
@@ -175,6 +188,103 @@ function formatAjvMessage(err: ErrorObject): string {
       : (err.message ?? 'missing required property');
   }
   return err.message ?? 'schema violation';
+}
+
+// ─────────────────────────────────────────────────────────────
+// Entry-shape probe
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * A top-level entry is a group (`tracks:`) or a standalone track
+ * (`data:`) — never neither, never both. The schema says this with a
+ * `oneOf` over `GroupConfig` / `TrackConfig`, which is correct but
+ * un-actionable when an entry matches no branch: Ajv flattens the two
+ * failed branches into a contradictory pair. For `{ id: 'orphan', kind:
+ * 'features' }` an author is told, at once, to add `tracks` AND to add
+ * `data` AND that the config "must match exactly one schema in oneOf" —
+ * and for the both-keys case, neither field is named at all.
+ *
+ * These configs are authored by non-coders in a playground, so this
+ * function detects the two ambiguous shapes directly and emits one
+ * message per offending entry naming the entry and the two fields.
+ * `validateConfig` then drops the Ajv errors under those entries, so the
+ * targeted message stands alone rather than being buried under the dump
+ * it replaces.
+ *
+ * Runs before the structural pass because that pass returns early on any
+ * Ajv failure — a check downstream of it would never execute for exactly
+ * the configs it exists to explain.
+ */
+function checkEntryShapes(config: unknown): {
+  issues: ValidationIssue[];
+  /** JSON-Pointer paths of the entries explained here. */
+  flagged: string[];
+} {
+  const issues: ValidationIssue[] = [];
+  const flagged: string[] = [];
+
+  if (!isPlainObject(config)) return { issues, flagged };
+  const rows = (config as { rows?: unknown }).rows;
+  // A missing or non-array `rows:` is the schema's problem, not ours.
+  if (!Array.isArray(rows)) return { issues, flagged };
+
+  rows.forEach((entry, index) => {
+    // A non-object entry (a bare string, a number) isn't an ambiguous
+    // shape — it isn't an entry at all. Ajv's "must be object" is
+    // already the right message, so leave it alone.
+    if (!isPlainObject(entry)) return;
+
+    const hasTracks = isSet(entry.tracks);
+    const hasData = isSet(entry.data);
+    // Exactly one present is a well-formed entry — nothing to say.
+    if (hasTracks !== hasData) return;
+
+    flagged.push(`/rows/${index}`);
+    issues.push({
+      path: `/rows/${index}`,
+      message: hasTracks
+        ? `Top-level entry ${describeEntry(entry, index)} has both 'tracks:' and 'data:' — a group has 'tracks:', a single track has 'data:', not both.`
+        : `Top-level entry ${describeEntry(entry, index)} is neither a group nor a track — a group needs 'tracks:', a single track needs 'data:'. Add one.`,
+      code: 'invalid-entry-shape',
+    });
+  });
+
+  return { issues, flagged };
+}
+
+/**
+ * Whether an Ajv error belongs to an entry the shape probe explained —
+ * the entry itself or anything nested inside it.
+ *
+ * The `/` in the descendant test is load-bearing: a bare `startsWith`
+ * would let a flagged `/rows/1` swallow every error under `/rows/10`.
+ */
+function isUnderFlaggedEntry(instancePath: string, flagged: string[]): boolean {
+  return flagged.some(
+    (p) => instancePath === p || instancePath.startsWith(`${p}/`)
+  );
+}
+
+/** `'my-id'` when the entry has a usable id, else `at index N`. */
+function describeEntry(entry: Record<string, unknown>, index: number): string {
+  const { id } = entry;
+  return typeof id === 'string' && id.length > 0 ? `'${id}'` : `at index ${index}`;
+}
+
+/** A plain (non-null, non-array) object — the only shape an entry can be. */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Whether a field was actually set by the author. An empty YAML key
+ * (`tracks:` with nothing after it) parses to `null` — a leftover stub,
+ * not a value — so `null` counts as unset alongside `undefined`. Matches
+ * `rows-alias.ts`, which treats an empty `rows:` / `groups:` stub the
+ * same way: one notion of "set" across the schema layer.
+ */
+function isSet(v: unknown): boolean {
+  return v !== undefined && v !== null;
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Purpose
covers issue #183 

## Approach
/groups/0: must have required property 'tracks'
/groups/0: must NOT have additional properties
/groups/0: must have required property 'data'
/groups/0: must match exactly one schema in oneOf
/rows/0: Top-level entry 'orphan' is neither a group nor a track — a group
         needs 'tracks:', a single track needs 'data:'. Add one.  [invalid-entry-shape]

option 2 from the issue, shaped like the rowsAliasConflict precedent: checkEntryShapes runs before the structural pass, since validateConfig returns early on any Ajv failure and a check in the semantic pass would never execute for exactly these configs.

## Testing

What test(s) did you write to validate and verify your changes?

## Visual changes

add screenshots/recordings if applicable

## Checklist

- [x] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed by all interested parties.
