### PR TITLE
Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ The viewer renders a single collapsible group "Domains" (label title-cased from 
 
 ### Learning more
 
-- **User guide.** The task-oriented [ProtVista user guide](https://ebi-webcomponents.github.io/protvista/) — embedding the viewer, authoring a config, built-in track kinds, loading your own data (CSV/TSV/JSON/BED), troubleshooting, and escape hatches. Rendered from [`docs/`](./docs) and the best starting point for newcomers.
+- **Tutorial.** The guided [end-to-end tutorial](https://ebi-webcomponents.github.io/protvista/tutorial) — add the component, point it at an accession, add your own track from a CSV, `extends` the default viewer, and theme it. The best starting point for newcomers.
+- **User guide.** The task-oriented [ProtVista user guide](https://ebi-webcomponents.github.io/protvista/) — embedding the viewer, authoring a config, built-in track kinds, loading your own data (CSV/TSV/JSON/BED), troubleshooting, and escape hatches. Rendered from [`docs/`](./docs).
 - **Configuration vs data.** [Configuration vs data](https://ebi-webcomponents.github.io/protvista/configuration-vs-data) explains the boundary between what your config controls and what a data provider must supply — the Intent/Representation split, with a diagram and a paired example.
 - **Schema reference.** [`specs/config-approach.md`](./specs/config-approach.md) documents every field (`rows`, `tracks`, `sources`, `defaults`, `extends`, `kind`, `data`, `rendering`, `dataTooltip`) with worked examples and edge-case semantics. This is the normative source.
 - **Canonical default.** [`src/default-config.yaml`](./src/default-config.yaml) is the UniProt viewer itself, authored in the new schema. Useful as a reference.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -127,6 +127,7 @@ export default defineConfig({
           label: 'Getting started',
           items: [
             { label: 'Overview', link: '/overview' },
+            { label: 'Tutorial', link: '/tutorial' },
             { label: 'Embed the viewer', link: '/embed' },
             { label: 'Author a config', link: '/configure' },
           ],

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -12,6 +12,7 @@ the "Representation". Documentation is licensed CC BY 4.0.
 
 ## User guide
 
+- [Tutorial](https://ebi-webcomponents.github.io/protvista/tutorial): the guided end-to-end path — add the component, point it at an accession, add your own track from a CSV, `extends` the default viewer, and theme it.
 - [Overview and audience router](https://ebi-webcomponents.github.io/protvista/overview): where to start as a researcher, data owner, or developer.
 - [Embed the viewer](https://ebi-webcomponents.github.io/protvista/embed): load the component (module script or npm) and the key attributes (`accession`, `config-src`, `viewerConfig`, `notooltip`, …).
 - [Author a config](https://ebi-webcomponents.github.io/protvista/configure): `accession`, `sources`, `rows`/`tracks`, `kind`, `data`, `filter`; the minimal config and `extends`.

--- a/docs/src/content/docs/adapter-reference.md
+++ b/docs/src/content/docs/adapter-reference.md
@@ -99,6 +99,5 @@ These adapters back the built-in semantic `kind`s. Their input is a response fro
 - [specs/config-approach.md](https://github.com/ebi-webcomponents/protvista/blob/next/specs/config-approach.md) — normative Intent/Representation split.
 - [specs/generic-format-adapters.md](https://github.com/ebi-webcomponents/protvista/blob/next/specs/generic-format-adapters.md) — normative generic-format contract.
 - [examples/](https://github.com/ebi-webcomponents/protvista/tree/next/examples) — runnable, CI-validated config + data pairs.
-- Shape-correct mocks (#150) and React integration (#155) track downstream ownership of these shapes.
 
 _Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)._

--- a/docs/src/content/docs/data-tooltip.md
+++ b/docs/src/content/docs/data-tooltip.md
@@ -26,7 +26,7 @@ tracks:
 
 A declarative list of labelled rows. Each entry renders as `<h5>label</h5><p>value</p>`. Use this when the tooltip is a flat property sheet without prose or conditional content.
 
-`path` is a dotted path against the item (e.g. `association.0.name`). Missing or empty values drop out silently rather than rendering an empty row. The value at `path` is coerced to string, HTML-escaped, and wrapped in `<p>` at the leaf. There is no per-field render hook — for rich, interactive, or stateful tooltips (xref badges, evidence icons, taxonomy lookups, React components, …), listen for the Nightingale `change` event on the element and mount your own UI, setting the `notooltip` attribute on `<protvista-uniprot>` to suppress the built-in popover.
+`path` is a dotted path against the item (e.g. `association.0.name`). Missing or empty values drop out silently rather than rendering an empty row. The value at `path` is coerced to string, HTML-escaped, and wrapped in `<p>` at the leaf. There is no per-field render hook; when you need rich, interactive, or stateful tooltips (xref badges, evidence icons, taxonomy lookups, React components, …), own the overlay in the host instead — see [React host integration](/protvista/react-integration).
 
 ```yaml
 tracks:
@@ -66,3 +66,5 @@ tracks:
 ## When to leave `dataTooltip` off
 
 For every track in the default config, no `dataTooltip` is set. Each semantic `kind` carries a sensible tooltip default — authors who just want the canonical UniProt look get it for free. Only set `dataTooltip` when you want a track-specific override, or when you're authoring a track that doesn't match an existing kind's default.
+
+_Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)._

--- a/docs/src/content/docs/embed.md
+++ b/docs/src/content/docs/embed.md
@@ -34,6 +34,11 @@ then use the tag:
 <protvista-uniprot accession="P05067"></protvista-uniprot>
 ```
 
+`protvista-uniprot.mjs` is the built bundle. Until 5.0 is published, produce it
+from source with `yarn install && yarn build` in a clone of the
+[repository](https://github.com/ebi-webcomponents/protvista) and copy
+`dist/protvista-uniprot.mjs` next to your page.
+
 ### 2. As an npm package
 
 Install `protvista-uniprot` and import it once — the element self-registers as
@@ -47,6 +52,13 @@ import 'protvista-uniprot';
 ```html
 <protvista-uniprot accession="P05067"></protvista-uniprot>
 ```
+
+:::caution
+The published release is `protvista-uniprot@4.9.3`, which predates the config
+surface these docs describe (`rows:`, `kind:`, `extends:`). Until 5.0 ships,
+`npm install` gives you a viewer that will not read the configs in this guide —
+build from source as above.
+:::
 
 Either way, the tag behaves like any other HTML element — style it, size it,
 and place it wherever you like.

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -24,7 +24,9 @@ renders protein annotations as horizontal **tracks** aligned to the amino-acid
 sequence. Give it a UniProt **accession** and an optional YAML/JSON **config**;
 it fetches, draws, and lays out the rest.
 
-Pick a starting point above, or read the **[Overview](/protvista/overview)** for
-what it does, who it's for, and where to go next.
+New here? The end-to-end **[Tutorial](/protvista/tutorial)** takes you from an
+empty page to a custom, themed viewer in four steps. Or pick a starting point
+above, or read the **[Overview](/protvista/overview)** for what it does, who it's
+for, and where to go next.
 
 _Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)._

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -25,8 +25,8 @@ sequence. Give it a UniProt **accession** and an optional YAML/JSON **config**;
 it fetches, draws, and lays out the rest.
 
 New here? The end-to-end **[Tutorial](/protvista/tutorial)** takes you from an
-empty page to a custom, themed viewer in four steps. Or pick a starting point
-above, or read the **[Overview](/protvista/overview)** for what it does, who it's
-for, and where to go next.
+empty page to a custom, themed viewer in four steps. Otherwise pick a starting
+point above, or read the **[Overview](/protvista/overview)** for what it does,
+who it's for, and where to go next.
 
 _Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)._

--- a/docs/src/content/docs/overview.md
+++ b/docs/src/content/docs/overview.md
@@ -29,7 +29,9 @@ that to the right components, data adapters, and layout for you.
 
 ## Find your path
 
-- **New here?** Start with [Embed the viewer](/protvista/embed), then
+- **New here?** Take the end-to-end [Tutorial](/protvista/tutorial) — from an
+  empty page to a custom, themed viewer in four steps. For the pieces on their
+  own, see [Embed the viewer](/protvista/embed) then
   [Author a config](/protvista/configure).
 - **Bringing your own data?** Go straight to
   [Load your own data](/protvista/your-data).

--- a/docs/src/content/docs/react-integration.md
+++ b/docs/src/content/docs/react-integration.md
@@ -122,3 +122,5 @@ const hostRef = (el: HTMLElement | null) => {
 ```
 
 Prefer this once you're on React 19 — don't copy the split mount/unmount `useEffect` shape as the canonical form.
+
+_Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)._

--- a/docs/src/content/docs/theming.md
+++ b/docs/src/content/docs/theming.md
@@ -16,9 +16,6 @@ Internal class names (the hash-prefixed `.pv-*` classes) are **not** a
 public API and may change between releases — theme through the tokens
 and parts below instead.
 
-> This document is licensed CC BY 4.0, like the rest of the ProtVista
-> documentation.
-
 ## Why two mechanisms?
 
 The main viewer and the structure panel render in the **light DOM**
@@ -193,3 +190,5 @@ protvista-uniprot-datatable::part(row):hover {
   accessibility work; likewise a token-swap on top of this layer.
 - **No-code styling panel** — the interactive playground will let
   non-developers adjust these tokens with live preview.
+
+_Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)._

--- a/docs/src/content/docs/tutorial.md
+++ b/docs/src/content/docs/tutorial.md
@@ -21,15 +21,32 @@ can also work in your own page served by any static file server or your app's de
 server, or use the [playground](/protvista/playground/) for the config-only
 steps. No build tooling is required.
 
+:::note
+These docs describe the **unreleased 5.0 config surface** (`rows:`, `kind:`,
+`extends:`). The current npm release, `protvista-uniprot@4.9.3`, predates it and
+will not read the configs below — Step 1 shows how to get a matching build.
+:::
+
 ## Step 1: Add the component and point it at an accession
 
 `<protvista-uniprot>` is a **web component**: a custom element that works in any
-page with no build step. Load it once and drop the tag in with an accession:
+page with no bundler or framework. Load it once and drop the tag in with an
+accession:
 
 ```html
 <script type="module" src="./protvista-uniprot.mjs"></script>
 
 <protvista-uniprot accession="P05067"></protvista-uniprot>
+```
+
+`protvista-uniprot.mjs` is the component's built ES-module bundle. Until 5.0 is
+published to npm, build it from source and copy it next to your page:
+
+```sh
+git clone https://github.com/ebi-webcomponents/protvista
+cd protvista
+yarn install && yarn build
+# then copy dist/protvista-uniprot.mjs next to your HTML page
 ```
 
 That single attribute gives you the **full default UniProt viewer** for the
@@ -45,8 +62,8 @@ Swap the accession in the header to view any other protein.
      track groups. Capture from the running site; needs descriptive alt text. -->
 
 
-[Embed the viewer](/protvista/embed) covers the npm install path and every
-attribute (`config-src`, `notooltip`, `nostructure`, …).
+[Embed the viewer](/protvista/embed) covers both ways to load the component and
+every attribute (`config-src`, `notooltip`, `nostructure`, …).
 
 ## Step 2: Add your own track from a CSV
 
@@ -181,6 +198,14 @@ protvista-uniprot {
   --protvista-group-label-bg: #efe6f5;
 }
 ```
+
+:::caution
+The two levers are not additive: a config `theme:` **wins**. `labelColor` and
+`accentColor` are applied as inline styles on the element, so they override page
+CSS targeting the same tokens — including both tokens in the example above. Pick
+one lever, or force the CSS with `!important`. See
+[No-code theming from the config](/protvista/theming#no-code-theming-from-the-config).
+:::
 
 [Theme the viewer](/protvista/theming) lists every token and the datatable
 `::part` hooks.

--- a/docs/src/content/docs/tutorial.md
+++ b/docs/src/content/docs/tutorial.md
@@ -1,0 +1,211 @@
+---
+title: Tutorial
+description: "Go from an empty page to a custom, themed protein viewer in four steps: add the component, point it at an accession, add your own track from a CSV, and style it."
+---
+
+This is the guided, end-to-end path: start from nothing and finish with a
+working viewer that shows the full UniProt annotation for a protein **plus your
+own track**, recoloured to match your site. It's one continuous example on a
+single protein: [`P05067`](https://www.uniprot.org/uniprotkb/P05067), amyloid
+precursor protein, the reference accession used throughout these docs.
+
+Each step ends with a **Try it live** link that opens the exact setup in the
+[playground](/protvista/playground/), so you can see it render and edit it
+without leaving the browser. When you want the full detail behind a step, follow
+the links to the how-to guides.
+
+The quickest way to follow along is the
+**[Starter Kit](https://github.com/ebi-webcomponents/protvista-starter-kit)**: a
+no-build template repository you can copy and open straight in the browser. You
+can also work in your own page served by any static file server or your app's dev
+server, or use the [playground](/protvista/playground/) for the config-only
+steps. No build tooling is required.
+
+## Step 1: Add the component and point it at an accession
+
+`<protvista-uniprot>` is a **web component**: a custom element that works in any
+page with no build step. Load it once and drop the tag in with an accession:
+
+```html
+<script type="module" src="./protvista-uniprot.mjs"></script>
+
+<protvista-uniprot accession="P05067"></protvista-uniprot>
+```
+
+That single attribute gives you the **full default UniProt viewer** for the
+protein: domains, variants, binding sites, structure coverage, AlphaFold
+confidence, and more. No config required.
+
+:::tip[Try it live]
+Open the [default viewer for P05067](/protvista/playground/#preset=uniprot-default&accession=P05067).
+Swap the accession in the header to view any other protein.
+:::
+
+<!-- TODO(screenshot): the full default UniProt viewer for P05067 — all built-in
+     track groups. Capture from the running site; needs descriptive alt text. -->
+
+
+[Embed the viewer](/protvista/embed) covers the npm install path and every
+attribute (`config-src`, `notooltip`, `nostructure`, …).
+
+## Step 2: Add your own track from a CSV
+
+Now bring your own annotations. A `features` track can read a **CSV** file
+directly: point `data:` at the file and the `.csv` extension picks the parser for
+you: no `adapter:` needed.
+
+Say your lab has flagged some hotspot regions. Put them in a CSV with the
+feature-record columns `type,start,end,description,score`:
+
+```csv
+type,start,end,description,score
+DOMAIN,18,289,Extracellular domain (custom re-annotation),0.95
+BINDING,132,140,Predicted heparin-binding site,0.87
+REGION,290,340,Acidic-rich linker region,0.6
+MUTAGEN,614,614,Lab-observed loss-of-function point mutation,0.75
+```
+
+Then describe a viewer that shows just that file as one standalone track (a
+`rows:` entry with `data:` and no `tracks:` needs no group wrapper):
+
+```yaml
+accession: P05067
+rows:
+  - id: hotspots
+    label: Hotspots
+    kind: features
+    data: ./hotspots.csv
+    description: Hotspot regions identified by our lab's pipeline
+```
+
+Save the config as `my-config.yaml` next to `hotspots.csv` and point the element
+at it:
+
+```html
+<protvista-uniprot config-src="./my-config.yaml"></protvista-uniprot>
+```
+
+:::caution
+`data: ./hotspots.csv` is fetched **relative to the hosting page**, not the
+config file. If a file-backed track renders empty, this is the usual cause:
+serve the page from the same directory as the data, or use an absolute URL.
+:::
+
+:::tip[Try it live]
+Open [the CSV track in the playground](/protvista/playground/#preset=csv). It
+renders the same config against a hosted copy of `hotspots.csv`.
+:::
+
+<!-- TODO(screenshot): the standalone "Hotspots" CSV track rendered on its own. -->
+
+
+[Load your own data](/protvista/your-data) covers the full feature record and the
+TSV, JSON, and BED formats.
+
+## Step 3: Layer it onto the full UniProt viewer
+
+A standalone track is a viewer of its own. More often you want your track *on top
+of* everything UniProt already provides. Instead of rebuilding the default
+viewer, **`extends`** it: you inherit all its sources, groups, and themes, and
+declare only your addition.
+
+The custom data can be simpler here — the default viewer supplies the rest:
+
+```csv
+type,start,end,description,score
+DOMAIN,18,289,Custom re-annotation of the extracellular domain,0.9
+BINDING,614,614,Lab-observed candidate binding residue,0.72
+```
+
+```yaml
+accession: P05067
+extends: /src/default-config.yaml
+
+rows:
+  - id: MY_LAB
+    label: My lab
+    tracks:
+      - id: hotspots
+        kind: features
+        data: ./hotspots.csv
+        description: Hotspot regions identified by our lab's pipeline, layered on top of the canonical UniProt viewer
+```
+
+That's the whole config: the full canonical viewer, with a **My lab** group added
+at the end.
+
+:::caution
+`extends: /src/default-config.yaml` resolves only when the page is served from
+this repo's root (e.g. `yarn start`); a deployed site or a fresh Starter Kit
+project must point `extends` at its own hosted copy instead. See
+[Author a config](/protvista/configure#reuse-the-default-with-extends) for the
+merge rules and the full caveat.
+:::
+
+:::tip[Try it live]
+Open the [full default viewer](/protvista/playground/#preset=uniprot-default) to
+see the base you're extending. To see it combined with your track, run the docs
+site locally (`yarn docs:dev`), where `/src/default-config.yaml` resolves.
+:::
+
+<!-- TODO(screenshot): the "My lab" group layered on top of the full default
+     viewer (captured from `yarn docs:dev`, where the extends path resolves). -->
+
+## Step 4: Style it
+
+Finally, make it yours. There are two levers, no rebuild required.
+
+**No code: from the config.** A `theme:` block recolours the viewer chrome
+directly, so an author who doesn't write CSS can still brand the viewer.
+`labelColor` sets the row-label panel; the optional `accentColor` sets focus
+rings and the datatable's active-row marker:
+
+```yaml
+theme:
+  labelColor: '#e8f5e9'
+  accentColor: '#2e7d32'
+```
+
+:::tip[Try it live]
+Open the [inline-data preset](/protvista/playground/#preset=inline-data), which
+carries a `theme:` block — edit the colours and press **Run**.
+:::
+
+**From your page's CSS.** For full control, `<protvista-uniprot>` exposes
+`--protvista-*` design tokens and `::part` hooks — set them in ordinary CSS on
+the page:
+
+```css
+protvista-uniprot {
+  --protvista-color-accent: #7b2d8e;
+  --protvista-group-label-bg: #efe6f5;
+}
+```
+
+[Theme the viewer](/protvista/theming) lists every token and the datatable
+`::part` hooks.
+
+<!-- TODO(screenshot): the recoloured viewer after theming (theme.labelColor /
+     accentColor, or the CSS custom properties). -->
+
+## You're done
+
+You went from an empty page to a viewer that shows the full UniProt annotation
+for a protein, adds your own track from a CSV, and matches your site's colours.
+
+Where to go next:
+
+- [Author a config](/protvista/configure) — every field a config can hold.
+- [Load your own data](/protvista/your-data) — TSV, JSON, BED, and inline data.
+- [Theme the viewer](/protvista/theming) — the full token and `::part` reference.
+- [Configuration vs data](/protvista/configuration-vs-data) — what your config
+  controls versus what a data provider supplies.
+- [Escape hatches](/protvista/escape-hatches) — custom parsers, kinds, and themes
+  when the built-ins aren't enough.
+- [Playground](/protvista/playground/) — edit any config live and share it by link.
+- [Starter Kit](https://github.com/ebi-webcomponents/protvista-starter-kit) — a
+  no-build template repository to copy and go.
+- [Runnable examples](https://github.com/ebi-webcomponents/protvista/tree/next/examples)
+  — the CI-validated configs this tutorial draws from.
+
+_Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)._

--- a/src/__spec__/tutorial-doc.spec.ts
+++ b/src/__spec__/tutorial-doc.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Drift test for the paired examples embedded in
+ * `docs/src/content/docs/tutorial.md`. The end-to-end tutorial hand-copies its
+ * config and CSV snippets from the CI-validated `examples/` directory into
+ * fenced `yaml`/`csv` blocks. Nothing else pins those embedded copies to the
+ * real files, so `examples/csv/*` or `examples/extend-default/*` could change
+ * and the tutorial would silently drift. This closes that gap, exactly as
+ * `configuration-vs-data-doc.spec.ts` does for that page.
+ *
+ * The tutorial embeds two example pairs, so it has multiple `yaml`/`csv`
+ * blocks. `allFenced` returns them in document order:
+ *   - yaml[0] / csv[0] — Step 2, the standalone CSV track (examples/csv).
+ *   - yaml[1] / csv[1] — Step 3, the `extends` layer (examples/extend-default).
+ * Step 4's illustrative `theme:` block is yaml[2] and is not pinned (it is not
+ * copied from an example file).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Vitest runs from the repo root, so resolve paths from cwd.
+const read = (rel: string) => readFileSync(resolve(process.cwd(), rel), 'utf8');
+
+// Pull every fenced code block of a given language out of a Markdown doc, in
+// document order.
+const allFenced = (md: string, lang: string): string[] => {
+  const re = new RegExp('```' + lang + '\\n([\\s\\S]*?)```', 'g');
+  const blocks = [...md.matchAll(re)].map((m) => m[1]);
+  if (blocks.length === 0) throw new Error(`no ${lang} block found`);
+  return blocks;
+};
+
+describe('docs/src/content/docs/tutorial.md embedded examples stay in sync', () => {
+  const doc = read('docs/src/content/docs/tutorial.md');
+  const yaml = allFenced(doc, 'yaml');
+  const csv = allFenced(doc, 'csv');
+
+  it('the Step 2 csv block matches examples/csv/hotspots.csv verbatim', () => {
+    expect(csv[0].trim()).toBe(read('examples/csv/hotspots.csv').trim());
+  });
+
+  it('the Step 2 yaml block matches examples/csv/config.yaml', () => {
+    // The doc omits the file's leading `#` comment header, so the embedded
+    // block is a contiguous slice of the file — assert containment.
+    expect(read('examples/csv/config.yaml')).toContain(yaml[0].trim());
+  });
+
+  it('the Step 3 csv block matches examples/extend-default/hotspots.csv verbatim', () => {
+    expect(csv[1].trim()).toBe(read('examples/extend-default/hotspots.csv').trim());
+  });
+
+  it('the Step 3 yaml block matches examples/extend-default/config.yaml', () => {
+    // Same as above: the doc slices off the leading comment header.
+    expect(read('examples/extend-default/config.yaml')).toContain(yaml[1].trim());
+  });
+});

--- a/src/schema/adapters/render-adapter-reference.ts
+++ b/src/schema/adapters/render-adapter-reference.ts
@@ -160,9 +160,6 @@ export function renderReferenceMarkdown(
   lines.push(
     `- [examples/](${GITHUB_TREE}/examples) — runnable, CI-validated config + data pairs.`
   );
-  lines.push(
-    '- Shape-correct mocks (#150) and React integration (#155) track downstream ownership of these shapes.'
-  );
   lines.push('');
   lines.push(
     '_Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)._'


### PR DESCRIPTION
## Purpose

Fixes two gaps in the new onboarding tutorial. Step 1 told readers to load `./protvista-uniprot.mjs` without saying anywhere how to obtain it, so following the page literally gave a 404 and a blank viewer. Step 4 presented the config `theme:` block and page CSS as two interchangeable levers, when a config theme silently overrides page CSS targeting the same tokens — including both tokens used in the example directly below it.

## Approach

Step 1 now states that `protvista-uniprot.mjs` is the built ES-module bundle and gives the build-from-source steps, with the same note added to `embed.md`'s module-script section. Since the published release is `protvista-uniprot@4.9.3` and predates the `rows:`/`kind:`/`extends:` config surface these docs describe, both pages call that out explicitly rather than pointing at `npm install`, which would install a viewer that cannot read any config in the guide.

Step 4 gains a caution that the config `theme:` wins, explaining that `labelColor`/`accentColor` are applied as inline styles on the host, with a link to the precedence rules already documented in `theming.md`.

Also corrected line 48's claim that `embed.md` "covers the npm install path", and a doubled conjunction on the docs home page.

## Testing

No new tests — this is a documentation-only change with no code touched.

The existing drift test `src/__spec__/tutorial-doc.spec.ts` covers the tutorial's embedded `yaml`/`csv` blocks. The new `sh` block is a different language and does not shift the positional indices that test relies on; its four assertions were re-derived by hand against `examples/csv/*` and `examples/extend-default/*` and all still hold. The suite itself was not run.

Also checked by hand: the `#no-code-theming-from-the-config` anchor exists in `theming.md`, and the internal `/protvista/*` links in the edited files resolve to real content files.

Still owed: a real `yarn install && yarn build` run to confirm the build instructions added to Step 1 produce `dist/protvista-uniprot.mjs` as written. The output filename is read off `vite.config.mjs`, not observed.

## Visual changes

No component or styling changes. Rendered docs changes only: a build-from-source snippet and a release note in the tutorial's Step 1, a caution box at the end of Step 4, and two notes in `embed.md`. No screenshots captured.

## Checklist

- [ ] My PR is scoped properly, and "does one thing only"
- [ ] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed by all interested parties.