### PR TITLE
Create Starter Kit

### DIFF
--- a/.github/workflows/publish-starter-kit.yml
+++ b/.github/workflows/publish-starter-kit.yml
@@ -1,0 +1,138 @@
+# Publishes `starter-kit/` to the standalone template repository
+# `ebi-webcomponents/protvista-starter-kit`.
+#
+# The kit is developed here so the test suite can gate it
+# (`src/__spec__/starter-kit.spec.ts`); this workflow is the only thing that
+# copies it out. That direction is one-way: edits made directly in the template
+# repository are overwritten by the next release.
+#
+# Setup required once, before the first run:
+#   1. Generate a key pair:  ssh-keygen -t ed25519 -C protvista-starter-kit -f key
+#   2. Add `key.pub` to the TEMPLATE repository as a deploy key, WITH write
+#      access (Settings -> Deploy keys).
+#   3. Add the private key to THIS repository as the secret
+#      STARTER_KIT_DEPLOY_KEY (Settings -> Secrets and variables -> Actions).
+#   4. Tick "Template repository" in the template repository's settings.
+#
+# A deploy key rather than a personal access token: it is scoped to that one
+# repository, it does not expire, and it does not stop working when someone
+# leaves the organisation.
+name: Publish starter kit
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Show what would be published, but do not push"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  TARGET_REPO: ebi-webcomponents/protvista-starter-kit
+
+jobs:
+  # Split from `publish` deliberately: this job installs third-party
+  # dependencies and runs their lifecycle scripts, and must never share a
+  # runner with the deploy key.
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "yarn"
+
+      - run: yarn install --frozen-lockfile
+
+      # Never publish a kit the suite has not validated. This covers the
+      # version pin, the sample data, and that every config still loads and
+      # renders against the code being released.
+      - name: Validate the kit
+        run: yarn test:unit
+
+  publish:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      # No dependency install in this job — only `git`, `rsync`, `curl` and
+      # the runner's own `node`, all preinstalled.
+      - uses: actions/checkout@v4
+
+      - name: Publish
+        env:
+          DEPLOY_KEY: ${{ secrets.STARTER_KIT_DEPLOY_KEY }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DEPLOY_KEY:-}" ]; then
+            echo "::error::STARTER_KIT_DEPLOY_KEY is not set — see the setup notes in this workflow."
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes"
+
+          # A release supplies its tag; a manual run falls back to the version
+          # the kit is pinned to, which the test suite has just confirmed
+          # matches package.json.
+          TAG="${RELEASE_TAG:-}"
+          if [ -z "$TAG" ]; then
+            TAG="v$(node -p "require('./package.json').version")"
+          fi
+
+          git clone --depth 1 "git@github.com:${TARGET_REPO}.git" target
+
+          # Mirror the directory exactly, so a file deleted here is deleted
+          # there. --exclude .git protects the clone's own history.
+          rsync -a --delete --exclude '.git/' starter-kit/ target/
+
+          # The kit carries a "this does not work yet" notice while the version
+          # it pins is unpublished. Strip it once that version is actually on
+          # npm, so the release that makes the kit work cannot ship a banner
+          # saying it doesn't. Driven by the registry rather than by anyone
+          # remembering; src/__spec__/starter-kit.spec.ts keeps the markers
+          # balanced so this range delete stays reliable.
+          PINNED="$(node -p "require('./package.json').version")"
+          if curl --fail --silent --show-error \
+               "https://registry.npmjs.org/protvista-uniprot/${PINNED}" \
+               -o /dev/null 2>/dev/null; then
+            echo "protvista-uniprot@${PINNED} is published — removing the unpublished notice."
+            for f in target/index.html target/README.md; do
+              sed -i '/protvista:unpublished:start/,/protvista:unpublished:end/d' "$f"
+            done
+          else
+            echo "::warning::protvista-uniprot@${PINNED} is not on npm yet — publishing the kit with its 'does not work yet' notice intact."
+          fi
+
+          cd target
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+
+          if git diff --staged --quiet; then
+            echo "The template repository is already up to date with $TAG."
+            exit 0
+          fi
+
+          echo "Changes to publish as $TAG:"
+          git diff --staged --stat
+
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            echo "::notice::Dry run — nothing pushed."
+            exit 0
+          fi
+
+          git commit -m "Publish $TAG"
+          git push

--- a/docs/pages-site.md
+++ b/docs/pages-site.md
@@ -55,17 +55,27 @@ Which examples are surfaced is curated for a single hosted page (the rationale i
 - `csv` (a single standalone track — one row, no group) and `json` (a live UniProt API track next to the BYO file) are bring-your-own-file. The examples reference `data: ./hotspots.*`, which the loader resolves against the *page*, not the config's directory (see the path-resolution caveat in `examples/README.md`). So `presets.ts` repoints them at the site-absolute `/protvista/sample-data/hotspots.*`, served from `docs/public/sample-data/` (copies of `examples/csv|json/hotspots.*`). That is what makes the file-backed presets render on the playground page.
 - `extend-default` is omitted: it `extends: /src/default-config.yaml`, which the built `site/` bundle does not serve, so it can only load under the dev server. `tsv` (same shape as `csv`) and `bed` (niche) are omitted for brevity — add them to `PRESETS` if wanted.
 
-## Deliverables still to build
+## Q2 "Documentation and training" deliverables (done)
 
-These are the remaining Q2 "Documentation and training" pieces. The docs home and nav link to each one's home, so wiring them up is mostly authoring content and pointing the existing links at it. (The **user guide (#214)** and the **Starlight docs site** are already done — see the sections above.)
+Both remaining pieces have shipped; the **user guide (#214)** and the **Starlight docs site** are covered in the sections above.
 
-### Tutorial (#215)
+### Tutorial (#215) (done)
 
-End-to-end onboarding in `docs/`: add the component, point it at an accession, `extends` a config to add a custom track from a local CSV/TSV, then style it via tokens / `::part`. Reuse the `extends` example from `specs/config-approach.md` and the Starter Kit as the running example. Because the tutorial and the playground share the same config surface, the tutorial can deep-link into the playground with a shareable-link URL (a `#config=…` or `#preset=…` hash) so readers open the exact config being discussed. Author this **last** among the docs, after the config-surface renames settle. Licensed CC BY 4.0.
+`docs/src/content/docs/tutorial.md` — end-to-end onboarding: add the component, point it at an accession, add a custom track from a CSV, `extends` the default viewer, then style it. Its embedded config and CSV blocks are pinned to `examples/csv` and `examples/extend-default` by `src/__spec__/tutorial-doc.spec.ts`, so the samples cannot drift. Each step deep-links into the playground with a `#preset=…` hash. Licensed CC BY 4.0.
 
-### Starter Kit (#211)
+### Starter Kit (#211) (done)
 
-A separate template repository (`ebi-webcomponents/protvista-starter-kit`), not part of this repo: a no-build `index.html` loading the component from a pinned CDN, a commented `config.yaml`, and `data/` samples. It edits the **same config surface** the playground edits, so the two reinforce each other — the playground is where you experiment, the Starter Kit is where you start a real project. The hub already links out to it. An "Open in Playground" link (a shareable-link hash seeded from a starter config) is a natural addition once both exist.
+Authored at **`starter-kit/` in this repo** and published to the standalone template repository `ebi-webcomponents/protvista-starter-kit` by `.github/workflows/publish-starter-kit.yml` on release. Living here rather than being maintained separately is what makes `src/__spec__/starter-kit.spec.ts` possible: the kit's `config.yaml` and recipes get the same load → data-pipeline → smoke-render treatment `examples.spec.ts` gives `examples/`, so breaking the kit fails `yarn test:unit` in the PR that breaks it. There is no cross-repo sync to go stale.
+
+Resolved shape:
+
+- **Flat and small at the root** — `index.html`, `config.yaml`, `data/`, `recipes/` — so a non-coder sees "the page, the settings, my data". A published template gets clean single-commit history from "Use this template", which is why no history-preserving split (`git subtree split`/`splitsh-lite`) is warranted.
+- **One live config, two recipes.** The page has one `config-src`, so the standalone CSV track is `config.yaml` (tutorial Step 2) and `tsv.yaml` / `extend-uniprot.yaml` (Step 3) sit in `recipes/`, previewable via `?config=` without editing anything. Because `data:` resolves against the *page*, every recipe shares one `data/` folder.
+- **One version pin.** `index.html` pins the bundle and `recipes/extend-uniprot.yaml` pins `extends:` at the same jsDelivr version; `starter-kit.spec.ts` asserts both equal `package.json`'s version, so a release bump cannot ship a stale kit. That `extends:` URL depends on `src` staying in package.json `files` — pinned by `schema-publishing.spec.ts`.
+- **Fail-visible.** `index.html` ships a visible status notice removed only on confirmed success, so a CDN 404, a blocked network, or opening via `file://` can never present as a blank page.
+- **Placeholder until 5.0.0 publishes.** npm's latest is 4.9.3, which has no `config-src`, so the pinned CDN URL 404s today. The kit ships anyway, with the state flagged in the README and in the page itself between `protvista:unpublished` markers. The publish workflow queries the npm registry for the pinned version and `sed`-strips those blocks once it is live, so the release that makes the kit work cannot ship a banner saying it does not — no one has to remember. `starter-kit.spec.ts` keeps the markers balanced so that range delete stays reliable.
+
+Not yet done: the deploy key and the "Template repository" flag must be set up before the first publish (see the workflow header), and an "Open in Playground" link seeded from a starter config remains a natural addition.
 
 ### Publishing the docs on Pages (done)
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -37,6 +37,7 @@ the "Representation". Documentation is licensed CC BY 4.0.
 
 - [Configuration playground](https://ebi-webcomponents.github.io/protvista/playground/): edit a config with live validation and preview; `?dev` adds edge-case examples, `?accession=` seeds the viewer.
 - [Runnable examples](https://github.com/ebi-webcomponents/protvista/tree/next/examples): CI-validated config + data pairs (basic, inline, CSV, TSV, JSON, BED, extends-default).
+- [Starter Kit](https://github.com/ebi-webcomponents/protvista-starter-kit): a no-build template repository — an HTML page, a commented `config.yaml`, and a `data/` folder — for visualising your own CSV/TSV annotations without writing code. Loads the component from a version-pinned CDN.
 
 ## Optional
 

--- a/docs/src/content/docs/configure.md
+++ b/docs/src/content/docs/configure.md
@@ -151,7 +151,16 @@ rows:
 repository root (e.g. the dev server, `yarn start`). A deployed site does not
 serve `src/`, so an embedder who copies this verbatim gets a 404. For anything
 beyond local development, point `extends` at your own hosted copy of the config,
-or at a stable published URL.
+or at the published package on a CDN:
+
+```yaml
+extends: https://cdn.jsdelivr.net/npm/protvista-uniprot@5.0.0/src/default-config.yaml
+```
+
+That path is served straight from the npm tarball, so pin an exact version — a
+config written against one release is not guaranteed to merge cleanly into
+another. It resolves once 5.0.0 is published; see the release note on the
+[tutorial](/protvista/tutorial).
 :::
 
 ## Where to go next

--- a/docs/src/content/docs/tutorial.md
+++ b/docs/src/content/docs/tutorial.md
@@ -153,16 +153,19 @@ at the end.
 
 :::caution
 `extends: /src/default-config.yaml` resolves only when the page is served from
-this repo's root (e.g. `yarn start`); a deployed site or a fresh Starter Kit
-project must point `extends` at its own hosted copy instead. See
+this repo's root; a deployed site must point `extends` at a hosted copy instead —
+either your own, or the published package on a CDN:
+`https://cdn.jsdelivr.net/npm/protvista-uniprot@5.0.0/src/default-config.yaml`
+(available once 5.0.0 ships, as above). See
 [Author a config](/protvista/configure#reuse-the-default-with-extends) for the
 merge rules and the full caveat.
 :::
 
 :::tip[Try it live]
 Open the [full default viewer](/protvista/playground/#preset=uniprot-default) to
-see the base you're extending. To see it combined with your track, run the docs
-site locally (`yarn docs:dev`), where `/src/default-config.yaml` resolves.
+see the base you're extending. To see it combined with your track, switch
+`extends:` to the CDN URL above — that form resolves from any page, once 5.0.0
+ships.
 :::
 
 <!-- TODO(screenshot): the "My lab" group layered on top of the full default

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,24 @@ This is meant to become the single source of truth that the
 playground, Starter Kit, tutorial, and docs eventually all point at,
 rather than each maintaining their own divergent samples.
 
+Two consumers are pinned to these samples by tests, so changing one
+here surfaces immediately rather than silently:
+
+- **The tutorial** embeds `csv/` and `extend-default/` verbatim in
+  fenced code blocks; `src/__spec__/tutorial-doc.spec.ts` asserts they
+  still match.
+- **The Starter Kit** (`starter-kit/`, published to the standalone
+  template repository) ships the same shapes as its `config.yaml` and
+  `recipes/`, adapted to a flat `data/` folder.
+  `src/__spec__/starter-kit.spec.ts` runs those through the same
+  load → data → render pipeline this directory gets, and asserts its
+  three sample data files are byte-identical to `csv/hotspots.csv`,
+  `tsv/hotspots.tsv` and `extend-default/hotspots.csv` — so editing a
+  sample here fails that suite rather than leaving the kit stale. The
+  configs themselves are authored separately (the kit's paths and
+  comments differ), so a change to a `config.yaml` here does not
+  propagate automatically.
+
 ## What's here
 
 | Directory | Demonstrates |

--- a/src/__spec__/starter-kit.spec.ts
+++ b/src/__spec__/starter-kit.spec.ts
@@ -1,0 +1,338 @@
+/**
+ * Validates `starter-kit/` — the source of truth for the standalone
+ * template repository `ebi-webcomponents/protvista-starter-kit`, which
+ * is published from this directory on release (see
+ * `.github/workflows/publish-starter-kit.yml`).
+ *
+ * The kit lives in this repo precisely so that this suite can be its
+ * gate. A published template has no access to this toolchain, so
+ * without these tests the only thing standing between a schema change
+ * and a broken onboarding repo would be a cross-repo sync job noticing
+ * after the fact. Here, breaking the kit fails `yarn test:unit` in the
+ * PR that breaks it.
+ *
+ * Each of `config.yaml` and `recipes/*.yaml` gets the same three-stage
+ * treatment `examples.spec.ts` applies to `examples/` — load, run the
+ * real data pipeline, smoke-render — plus four checks specific to
+ * being a distributed artefact:
+ *
+ *   - every `protvista-uniprot@<version>` reference across the kit
+ *     matches this package's own version, so a release bump cannot
+ *     silently ship a kit pinned to the previous one;
+ *   - every relative `data:` path resolves to a file that exists;
+ *   - every CSV/TSV it ships carries the required header columns;
+ *   - `index.html` carries no `vendor/` reference, which would mean
+ *     the local-preview escape hatch (a hand-copied build, used to run
+ *     the kit before a release is published) had leaked into a commit.
+ *
+ * The helpers below deliberately mirror rather than import
+ * `examples.spec.ts`: importing across spec files would register that
+ * suite's tests a second time.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { render } from 'lit';
+
+import { loadConfig } from '../schema/load';
+import type { NormalizedConfig } from '../schema/normalize';
+import { loadProtvistaData } from '../load-data';
+import { createRegistry } from '../schema/registry';
+import { REQUIRED_COLUMNS } from '../schema/adapters/dsv';
+import { CSS_PREFIX } from '../styles/css-prefix';
+// Side-effect import: registers the custom element, so the smoke
+// render below exercises the real template.
+import '../protvista-uniprot';
+
+const registry = createRegistry();
+const resolveAdapter = (name: string) => registry.getAdapter(name);
+
+const REFERENCE_ACCESSION = 'P05067';
+const SEQ_LEN = 770;
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const KIT_ROOT = join(REPO_ROOT, 'starter-kit');
+
+const PACKAGE_VERSION: string = JSON.parse(
+  readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')
+).version;
+
+/** Every config file the kit ships, as page-relative paths. */
+const KIT_CONFIGS = [
+  'config.yaml',
+  'recipes/tsv.yaml',
+  'recipes/extend-uniprot.yaml',
+];
+
+/** Files that may carry a pinned `protvista-uniprot@<version>` reference. */
+const VERSION_PINNED_FILES = [
+  'index.html',
+  'README.md',
+  ...KIT_CONFIGS,
+];
+
+const CANNED_FEATURES_RESPONSE = {
+  features: [
+    { type: 'DOMAIN', begin: 1, end: 770, description: 'Fixture domain' },
+  ],
+};
+
+/**
+ * Resolve a reference the way the browser will. Everything in the kit
+ * is served from the kit root (that is where `index.html` sits), so
+ * both `./data/x.csv` and an origin-absolute `/data/x.csv` land in the
+ * same place — which is exactly the property that lets every recipe
+ * share one `data/` folder.
+ */
+const resolveLocalRef = (ref: string): string =>
+  ref.startsWith('/') ? join(KIT_ROOT, ref) : resolve(KIT_ROOT, ref);
+
+/**
+ * The kit's `extends:` target is a pinned jsDelivr URL, which cannot
+ * be fetched here — the version it names is published at release time,
+ * not now. Serving this repo's own `src/default-config.yaml` in its
+ * place is the honest substitution: jsDelivr will serve that exact
+ * file, because `package.json` ships `src` in its `files` array (an
+ * invariant pinned by `schema-publishing.spec.ts`).
+ */
+const extendsFetcher = async (ref: string): Promise<string> => {
+  if (/^https?:\/\//i.test(ref)) {
+    expect(
+      ref.endsWith('/src/default-config.yaml'),
+      `unexpected remote extends target: ${ref}`
+    ).toBe(true);
+    return readFile(join(REPO_ROOT, 'src/default-config.yaml'), 'utf8');
+  }
+  return readFile(resolveLocalRef(ref), 'utf8');
+};
+
+const fetchOne = async (
+  url: string,
+  responseType: 'json' | 'text'
+): Promise<unknown> => {
+  if (/^https?:\/\//i.test(url)) {
+    return responseType === 'json' ? CANNED_FEATURES_RESPONSE : '';
+  }
+  const text = await readFile(resolveLocalRef(url), 'utf8');
+  return responseType === 'json' ? JSON.parse(text) : text;
+};
+
+function buildInstance(overrides: Record<string, unknown>) {
+  const el = document.createElement('protvista-uniprot') as any;
+  el.sequence = 'M'.repeat(SEQ_LEN);
+  el.displayCoordinates = { start: 1, end: SEQ_LEN };
+  el.accession = REFERENCE_ACCESSION;
+  el.suspend = false;
+  el.loading = false;
+  el.rawData = {};
+  Object.assign(el, overrides);
+  return el;
+}
+
+/** Tracks backed by the kit's own sample files, rather than a canned URL. */
+function findLocalTracks(
+  config: NormalizedConfig
+): { trackId: string; key: string }[] {
+  const found: { trackId: string; key: string }[] = [];
+  for (const group of config.rows) {
+    for (const track of group.tracks) {
+      const from = track.data[0]?.from;
+      if (from === 'file' || from === 'inline') {
+        found.push({ trackId: track.id, key: `${group.id}-${track.id}` });
+      }
+    }
+  }
+  return found;
+}
+
+/** Every `data:` value in a raw config file, however it is nested. */
+function collectDataRefs(configText: string): string[] {
+  return [...configText.matchAll(/^\s*data:\s*(\S+)\s*$/gm)].map((m) => m[1]);
+}
+
+it('the starter kit is present and complete', () => {
+  expect(existsSync(KIT_ROOT), 'starter-kit/ should exist').toBe(true);
+  for (const rel of [...VERSION_PINNED_FILES, 'LICENSE', 'LICENSE-docs']) {
+    expect(existsSync(join(KIT_ROOT, rel)), `starter-kit/${rel}`).toBe(true);
+  }
+});
+
+describe('starter kit — distribution invariants', () => {
+  it('pins this package version everywhere it names one', () => {
+    const found: { file: string; version: string }[] = [];
+    for (const rel of VERSION_PINNED_FILES) {
+      const text = readFileSync(join(KIT_ROOT, rel), 'utf8');
+      for (const m of text.matchAll(/protvista-uniprot@(\d+\.\d+\.\d+)/g)) {
+        found.push({ file: rel, version: m[1] });
+      }
+    }
+
+    // index.html pins the bundle; extend-uniprot.yaml pins the config it
+    // extends. Both must exist, or the invariant is vacuous.
+    expect(
+      found.map((f) => f.file),
+      'expected a pinned version in index.html and recipes/extend-uniprot.yaml'
+    ).toEqual(
+      expect.arrayContaining(['index.html', 'recipes/extend-uniprot.yaml'])
+    );
+
+    for (const { file, version } of found) {
+      expect(
+        version,
+        `starter-kit/${file} pins protvista-uniprot@${version}, but this ` +
+          `package is ${PACKAGE_VERSION} — bump the kit alongside the release`
+      ).toBe(PACKAGE_VERSION);
+    }
+  });
+
+  it('carries no reference to the local-preview vendor/ directory', () => {
+    // `vendor/` holds a hand-copied build used to run the kit before a
+    // release exists (see the kit's .gitignore). Committing a reference
+    // to it would ship a template pointing at a file nobody else has.
+    const html = readFileSync(join(KIT_ROOT, 'index.html'), 'utf8');
+    expect(html).not.toMatch(/vendor\//);
+  });
+
+  it('ships sample data for every relative path its configs reference', () => {
+    for (const rel of KIT_CONFIGS) {
+      const text = readFileSync(join(KIT_ROOT, rel), 'utf8');
+      for (const ref of collectDataRefs(text)) {
+        if (/^https?:\/\//i.test(ref)) continue;
+        expect(
+          existsSync(resolveLocalRef(ref)),
+          `starter-kit/${rel} references ${ref}, which does not exist`
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('ships sample data byte-identical to the canonical examples', () => {
+    // `examples/README.md` tells maintainers that editing a sample there
+    // surfaces here rather than leaving the kit silently stale. That is
+    // only true if something actually compares them.
+    const pairs: [string, string][] = [
+      ['data/hotspots.csv', 'examples/csv/hotspots.csv'],
+      ['data/hotspots.tsv', 'examples/tsv/hotspots.tsv'],
+      ['data/hotspots-extends.csv', 'examples/extend-default/hotspots.csv'],
+    ];
+    for (const [kitRel, exampleRel] of pairs) {
+      expect(
+        readFileSync(join(KIT_ROOT, kitRel), 'utf8'),
+        `starter-kit/${kitRel} has drifted from ${exampleRel}`
+      ).toBe(readFileSync(join(REPO_ROOT, exampleRel), 'utf8'));
+    }
+  });
+
+  it('keeps the unpublished-release notice strippable', () => {
+    // The notice is removed at publish time by a `sed` range delete in
+    // .github/workflows/publish-starter-kit.yml, which fires once the
+    // pinned version is live on npm. That only works while the markers
+    // stay balanced and paired, so an unbalanced edit would silently
+    // ship the "does not work yet" banner on a working kit.
+    for (const rel of ['index.html', 'README.md']) {
+      const text = readFileSync(join(KIT_ROOT, rel), 'utf8');
+      const starts = [...text.matchAll(/protvista:unpublished:start/g)].length;
+      const ends = [...text.matchAll(/protvista:unpublished:end/g)].length;
+      expect(starts, `starter-kit/${rel}: unbalanced unpublished markers`).toBe(
+        ends
+      );
+      expect(
+        starts,
+        `starter-kit/${rel}: expected at most one unpublished block`
+      ).toBeLessThanOrEqual(1);
+      if (starts === 1) {
+        expect(
+          text.indexOf('protvista:unpublished:start'),
+          `starter-kit/${rel}: end marker precedes start marker`
+        ).toBeLessThan(text.indexOf('protvista:unpublished:end'));
+      }
+    }
+  });
+
+  it('ships delimited files carrying the required header columns', () => {
+    const files = ['data/hotspots.csv', 'data/hotspots.tsv', 'data/hotspots-extends.csv'];
+    for (const rel of files) {
+      const header = readFileSync(join(KIT_ROOT, rel), 'utf8')
+        .split('\n')[0]
+        .trim();
+      const columns = header.split(rel.endsWith('.tsv') ? '\t' : ',');
+      for (const required of REQUIRED_COLUMNS) {
+        expect(
+          columns,
+          `starter-kit/${rel} header is missing "${required}"`
+        ).toContain(required);
+      }
+    }
+  });
+});
+
+describe.each(KIT_CONFIGS)('starter kit config: %s', (relPath) => {
+  let config: NormalizedConfig;
+  let result: Awaited<ReturnType<typeof loadProtvistaData>>;
+
+  beforeAll(async () => {
+    const text = await readFile(join(KIT_ROOT, relPath), 'utf8');
+    config = await loadConfig(text, {
+      accession: REFERENCE_ACCESSION,
+      extendsFetcher,
+    });
+    result = await loadProtvistaData(
+      REFERENCE_ACCESSION,
+      config,
+      fetchOne,
+      resolveAdapter
+    );
+  });
+
+  it('validates against the schema', () => {
+    expect(config).toBeDefined();
+    expect(config.rows.length).toBeGreaterThan(0);
+  });
+
+  it('produces data through the real adapter map for its own tracks', () => {
+    expect(result.hasData).toBe(true);
+
+    const local = findLocalTracks(config);
+    expect(local.length, 'the kit authors at least one local track').toBeGreaterThan(0);
+
+    for (const { key } of local) {
+      const payload = result.data[key];
+      expect(Array.isArray(payload), `${key} should be an array`).toBe(true);
+      expect(
+        (payload as unknown[]).length,
+        `${key} should be non-empty`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('smoke-renders, including each of its own tracks', () => {
+    const el = buildInstance({
+      config,
+      data: result.data,
+      hasData: result.hasData,
+      openGroups: config.rows.map((g) => g.id),
+    });
+
+    const target = document.createElement('div');
+    render(el.render(), target);
+
+    expect(
+      target.querySelectorAll(
+        `.${CSS_PREFIX}-group__track, .${CSS_PREFIX}-group--standalone`
+      ).length
+    ).toBeGreaterThan(0);
+
+    for (const { trackId, key } of findLocalTracks(config)) {
+      const node = target.querySelector(
+        `[data-id="${CSS_PREFIX}-track_${trackId}"]`
+      );
+      expect(
+        node,
+        `${CSS_PREFIX}-track_${trackId} (${key}) should render`
+      ).not.toBeNull();
+    }
+  });
+});

--- a/src/schema/__spec__/schema-publishing.spec.ts
+++ b/src/schema/__spec__/schema-publishing.spec.ts
@@ -29,6 +29,14 @@ const schema = JSON.parse(readFileSync(schemaPath, 'utf8')) as {
   $id?: string;
 };
 
+// The one version every hardcoded CDN pin must name. Same source of
+// truth as starter-kit.spec.ts, so a release bump moves both in lockstep.
+const PACKAGE_VERSION: string = (
+  JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf8')) as {
+    version: string;
+  }
+).version;
+
 describe('JSON Schema — hosting invariants', () => {
   it('declares the canonical $id (no drift, no vanity/unreachable URL)', () => {
     expect(schema.$id).toBe(CANONICAL_SCHEMA_URL);
@@ -89,15 +97,54 @@ describe('npm distribution — files the Starter Kit fetches from the CDN', () =
   });
 });
 
+describe('CDN version pins — every jsDelivr pin tracks this release', () => {
+  // The Starter Kit and the docs both hardcode
+  // `cdn.jsdelivr.net/npm/protvista-uniprot@<version>/…` URLs. The kit's
+  // pins are already gated by starter-kit.spec.ts, but the docs' were
+  // not: on a version bump the kit would update under test pressure
+  // while the doc URLs silently went stale. This repo-wide check closes
+  // that gap, covering the kit and the docs from one source of truth.
+  it('names PACKAGE_VERSION in every jsDelivr protvista-uniprot URL', () => {
+    const pins = findCdnVersionPins();
+
+    // Non-vacuous guard: the files that carry a pin today must all be
+    // found, so a regex typo can't let this pass on zero matches.
+    expect(
+      pins.map((p) => p.file),
+      'expected jsDelivr pins in the kit and the docs to be scanned'
+    ).toEqual(
+      expect.arrayContaining([
+        'starter-kit/index.html',
+        'starter-kit/recipes/extend-uniprot.yaml',
+        'docs/src/content/docs/configure.md',
+        'docs/src/content/docs/tutorial.md',
+      ])
+    );
+
+    for (const { file, version } of pins) {
+      expect(
+        version,
+        `${file} pins protvista-uniprot@${version}, but this package is ` +
+          `${PACKAGE_VERSION} — bump it alongside the release`
+      ).toBe(PACKAGE_VERSION);
+    }
+  });
+});
+
 // ─────────────────────────────────────────────────────────────
-// Repo-wide placeholder scan. Walks the whole repository tree from the
-// root (so root-level files like `index.html` and `package.json` are
-// covered, not just a hand-picked set of directories), skipping VCS /
-// dependency / build-output dirs. Test fixtures and snapshots are NOT
-// excluded — a placeholder hiding in a config fixture is exactly the
-// kind of regression this guards against. Only this spec file is
-// skipped, since it necessarily names the placeholder-shaped strings
-// below as the very markers it scans for.
+// Repo-wide scans. A single walker (`eachRepoFile`) crosses the whole
+// repository tree from the root (so root-level files like `index.html`
+// and `package.json` are covered, not just a hand-picked set of
+// directories), skipping VCS / dependency / build-output dirs. Test
+// fixtures and snapshots are NOT excluded — a placeholder hiding in a
+// config fixture is exactly the kind of regression this guards against.
+// Only this spec file is skipped, since it necessarily names the
+// placeholder-shaped strings below as the very markers it scans for.
+//
+// Two checks ride on that walk: the placeholder scan
+// (`findPlaceholderReferences`) and the CDN version-pin check
+// (`findCdnVersionPins`), which keeps every jsDelivr `protvista-uniprot`
+// pin — in the kit and the docs alike — in step with this package.
 // ─────────────────────────────────────────────────────────────
 
 const SELF_PATH = fileURLToPath(import.meta.url);
@@ -139,31 +186,61 @@ const PLACEHOLDER_MARKERS: Array<string | RegExp> = [
 ];
 
 function findPlaceholderReferences(): string[] {
-  const root = process.cwd();
   const offenders: string[] = [];
-  scanPath(root, root, offenders);
+  eachRepoFile((relPath, content) => {
+    const hit = PLACEHOLDER_MARKERS.some((marker) =>
+      typeof marker === 'string'
+        ? content.includes(marker)
+        : marker.test(content)
+    );
+    if (hit) offenders.push(relPath);
+  });
   return offenders;
 }
 
-function scanPath(path: string, root: string, offenders: string[]): void {
+// Any versioned jsDelivr pin of the component. Anchoring on the CDN
+// prefix is deliberate: the bare `protvista-uniprot@4.9.3` mentions in
+// docs prose name the *published* release, which predates this one, and
+// must not be forced to the dev version. Broadening to another CDN host
+// later is a one-line change to this pattern.
+const CDN_PIN_RE = /cdn\.jsdelivr\.net\/npm\/protvista-uniprot@(\d+\.\d+\.\d+)/g;
+
+function findCdnVersionPins(): { file: string; version: string }[] {
+  const pins: { file: string; version: string }[] = [];
+  eachRepoFile((file, content) => {
+    for (const m of content.matchAll(CDN_PIN_RE)) {
+      pins.push({ file, version: m[1] });
+    }
+  });
+  return pins;
+}
+
+// Hand every scannable file to `visit` as a repo-relative path plus its
+// text, skipping VCS / dependency / build-output dirs and this spec.
+function eachRepoFile(
+  visit: (relPath: string, content: string) => void
+): void {
+  const root = process.cwd();
+  walk(root, root, visit);
+}
+
+function walk(
+  path: string,
+  root: string,
+  visit: (relPath: string, content: string) => void
+): void {
   if (path === SELF_PATH) return; // this file names the markers as data
   const stat = statOrNull(path);
   if (!stat) return; // e.g. an optional root entry that doesn't exist
   if (stat.isDirectory()) {
     for (const entry of readdirSync(path, { withFileTypes: true })) {
       if (entry.isDirectory() && IGNORE_DIR_NAMES.has(entry.name)) continue;
-      scanPath(join(path, entry.name), root, offenders);
+      walk(join(path, entry.name), root, visit);
     }
     return;
   }
   if (!SCAN_EXTENSIONS.has(extname(path))) return;
-  const content = readFileSync(path, 'utf8');
-  const hit = PLACEHOLDER_MARKERS.some((marker) =>
-    typeof marker === 'string' ? content.includes(marker) : marker.test(content)
-  );
-  if (hit) {
-    offenders.push(path.replace(`${root}/`, ''));
-  }
+  visit(path.replace(`${root}/`, ''), readFileSync(path, 'utf8'));
 }
 
 function statOrNull(path: string): ReturnType<typeof statSync> | null {

--- a/src/schema/__spec__/schema-publishing.spec.ts
+++ b/src/schema/__spec__/schema-publishing.spec.ts
@@ -62,6 +62,33 @@ describe('JSON Schema — hosting invariants', () => {
   });
 });
 
+describe('npm distribution — files the Starter Kit fetches from the CDN', () => {
+  // The Starter Kit (`starter-kit/`, published to
+  // ebi-webcomponents/protvista-starter-kit) ships a recipe whose
+  // `extends:` points at
+  // https://cdn.jsdelivr.net/npm/protvista-uniprot@<version>/src/default-config.yaml
+  //
+  // jsDelivr serves that path straight out of the npm tarball, so it
+  // exists only while `src` stays in package.json `files`. Trimming
+  // that to `["dist"]` is an obvious-looking size win — the tarball
+  // carries all of src/**/*.ts as dead weight — and it would silently
+  // 404 every Starter Kit copy in the wild, with nothing else in this
+  // repo failing. Hence this test.
+  const pkg = JSON.parse(
+    readFileSync(resolve(process.cwd(), 'package.json'), 'utf8')
+  ) as { files?: string[] };
+
+  it('publishes `src`, which the Starter Kit `extends:` URL resolves into', () => {
+    expect(pkg.files).toContain('src');
+  });
+
+  it('still ships the config that URL points at', () => {
+    expect(
+      statOrNull(resolve(process.cwd(), 'src/default-config.yaml'))
+    ).not.toBeNull();
+  });
+});
+
 // ─────────────────────────────────────────────────────────────
 // Repo-wide placeholder scan. Walks the whole repository tree from the
 // root (so root-level files like `index.html` and `package.json` are

--- a/starter-kit/.github/workflows/validate.yml
+++ b/starter-kit/.github/workflows/validate.yml
@@ -1,0 +1,38 @@
+# Checks config.yaml (and the recipes) against ProtVista's published config
+# schema on every push, so a typo shows up here rather than as a blank page.
+#
+# This is a shape check only: it catches unknown or misspelled fields, wrong
+# types, and missing required ones. It cannot tell you a `data:` path points at
+# a file that isn't there — for that, load the page.
+name: Validate config
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Fetch the published schema
+        run: |
+          curl --fail --silent --show-error --retry 3 --retry-delay 2 \
+            -o config.schema.json \
+            https://ebi-webcomponents.github.io/protvista/schema/v1/config.schema.json
+
+      # --spec=draft2020 is required: this schema is JSON Schema 2020-12, and
+      # ajv's default draft-07 mode refuses to compile it. --strict=false
+      # matches how ProtVista itself compiles the schema.
+      - name: Validate
+        run: |
+          npx --yes ajv-cli@5 validate \
+            --spec=draft2020 --strict=false \
+            -s config.schema.json \
+            -d config.yaml -d "recipes/*.yaml"

--- a/starter-kit/.gitignore
+++ b/starter-kit/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+node_modules/
+
+# Only needed if you are testing against a locally built copy of the viewer
+# rather than the CDN.
+vendor/

--- a/starter-kit/LICENSE
+++ b/starter-kit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 EBI Web Components
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/starter-kit/LICENSE-docs
+++ b/starter-kit/LICENSE-docs
@@ -1,0 +1,4 @@
+Documentation and other non-code materials in this repository are licensed
+under the Creative Commons Attribution 4.0 International (CC BY 4.0) licence.
+
+See: https://creativecommons.org/licenses/by/4.0/

--- a/starter-kit/README.md
+++ b/starter-kit/README.md
@@ -1,0 +1,125 @@
+# ProtVista Starter Kit
+
+A template repository for putting your own protein annotations on screen next to UniProt's — no build step, no npm, no JavaScript.
+
+<!-- protvista:unpublished:start -->
+**Read this first: this template does not work yet**
+
+> ProtVista 5.0.0 has not been published to npm. `index.html` pins `protvista-uniprot@5.0.0` on jsDelivr, that address returns "not found" today, and the page shows a "Could not load the viewer" box instead of a protein.
+>
+> Everything else in the kit is real and final — the config, the sample data, the validation, the layout. Nothing here needs to change when 5.0.0 ships; the same files simply start working. Watch [the releases page](https://github.com/ebi-webcomponents/protvista/releases), then reload.
+>
+> To see the same configuration working right now, open the [ProtVista playground](https://ebi-webcomponents.github.io/protvista/playground/).
+<!-- protvista:unpublished:end -->
+
+## Use it
+
+1. Click **Use this template** at the top of this page, and give your copy a name.
+2. Get the files onto your computer: **Code → Download ZIP**, then unpack it. (If you use Git, cloning works too.)
+3. Serve the folder — see below.
+4. Open the address the server prints, usually <http://localhost:8000/>.
+5. Edit `config.yaml`, save, reload the page.
+
+**Why step 3 matters.** Browsers refuse to let a page opened straight from disk (a `file://` address) read other local files, so double-clicking `index.html` shows an orange box telling you to use a web server instead. The viewer cannot read its own config any other way.
+
+There are two ways to do it. **Neither requires you to write any code.**
+
+**Without a terminal — publish it.** In your new repository go to **Settings → Pages** and set the source to your default branch. GitHub serves the kit as a real website in a minute or two, and you can edit `config.yaml` straight in the GitHub web editor. This is the simplest route if you have never used a terminal, and it is covered again under [Publish your viewer](#publish-your-viewer).
+
+**With a terminal — run it locally.** Open **Terminal** on macOS or Linux, or **Command Prompt** on Windows, move into the unpacked folder (`cd` followed by the folder's path), and run one of:
+
+```sh
+python3 -m http.server 8000    # macOS / Linux
+py -m http.server 8000         # Windows
+```
+
+Leave that window open while you use the viewer; closing it stops the server. If the command is not found, you do not have Python installed — use the GitHub Pages route above instead, or any other static file server you already have.
+
+## What's in here
+
+| Path | What it is |
+| --- | --- |
+| `index.html` | The page. You will rarely need to touch it. |
+| `config.yaml` | Your viewer: which protein, which tracks, which files. This is the file you edit. |
+| `data/` | Your annotation files. Three samples ship here. |
+| `recipes/` | Alternative configs to try — see [`recipes/README.md`](./recipes/README.md). |
+| `.github/workflows/` | An automatic check on `config.yaml` — see below. |
+
+### About the automatic check
+
+Your copy comes with one GitHub Action that validates `config.yaml` against ProtVista's published schema every time you push. If you mistype a setting, the repository shows a red ✕ and GitHub emails you — that is the check telling you the config is wrong, not your repository being broken. Open the failed run to see which field it objected to.
+
+It is a convenience, not a requirement. If you would rather not have it, delete the `.github/` folder; nothing else depends on it.
+
+## Put your own data in
+
+Drop a CSV or TSV file into `data/`, then point `config.yaml` at it. The file needs a header row with these columns:
+
+| Column | Required | What it holds |
+| --- | --- | --- |
+| `type` | yes | The kind of feature, e.g. `DOMAIN`, `BINDING`, `REGION`, `MUTAGEN` |
+| `start` | yes | First residue, counting from 1 |
+| `end` | yes | Last residue. Same as `start` for a single-residue feature. |
+| `description` | yes | Free text, shown in the tooltip |
+| `score` | no | A number, if you have one |
+
+So a minimal file looks like this:
+
+```csv
+type,start,end,description,score
+DOMAIN,18,289,Extracellular domain (custom re-annotation),0.95
+BINDING,132,140,Predicted heparin-binding site,0.87
+```
+
+and `config.yaml` points at it like this:
+
+```yaml
+data: ./data/my-features.csv
+```
+
+One thing that catches people out: paths in `data:` are resolved against **the page**, not against `config.yaml`. They start from the folder holding `index.html`. Keep your files under `data/` and the `./data/…` form always works.
+
+The samples all use [`P05067`](https://www.uniprot.org/uniprotkb/P05067) — amyloid precursor protein, 770 residues — so the coordinates in them make sense. Change `accession:` to your own protein and your own coordinates together.
+
+For TSV, JSON and BED files, and for embedding data directly in the config, see [Load your own data](https://ebi-webcomponents.github.io/protvista/your-data).
+
+## This kit needs internet access
+
+Even with all your data in local files. The viewer is built around a UniProt accession and fetches that protein's sequence before it draws anything, so there is always one network request. It is not an offline tool.
+
+## When something doesn't show up
+
+| What you see | Usual cause |
+| --- | --- |
+| An orange box saying the viewer could not load | The component itself did not download — see the note at the top of this file, or check your connection. |
+| An orange box saying "Open this page through a web server" | You opened `index.html` directly instead of serving the folder. See step 3. |
+| It still says "Loading the viewer…" | Usually a very old browser. Try a current Firefox, Chrome, Edge or Safari. |
+| The viewer draws, but your track is empty | The path in `data:` does not resolve. Remember it starts from the folder holding `index.html`, not from `config.yaml`. |
+| "No feature data available" | A wrong `accession:`, coordinates past the end of the protein, or a data file that could not be parsed. |
+| You suspect your file is malformed | Open the browser's developer console (F12) — a file that fails to parse reports the reason there, naming the row and column. |
+
+More at [Troubleshooting](https://ebi-webcomponents.github.io/protvista/troubleshooting).
+
+## Publish your viewer
+
+In your repository's **Settings → Pages**, set the source to your default branch. GitHub serves the kit as a website within a minute or two, and because it is all static files there is nothing else to configure.
+
+Do check what is in `data/` before you do this. Publishing the site publishes those files too — anyone with the address can read them.
+
+## Getting help
+
+Questions, bugs, and suggestions go to the main [ProtVista repository](https://github.com/ebi-webcomponents/protvista/issues) — your copy of this template has no maintainers watching it.
+
+The full documentation is at <https://ebi-webcomponents.github.io/protvista/>, and the [tutorial](https://ebi-webcomponents.github.io/protvista/tutorial) walks through the same ground as this kit in more detail.
+
+## Licensing
+
+The code in this template is licensed under the MIT License (see `LICENSE`).
+
+Documentation and sample data are licensed under the Creative Commons Attribution 4.0 International (CC BY 4.0), unless otherwise stated (see `LICENSE-docs`).
+
+A viewer you build from this template is yours — licence it however you like.
+
+## Funding
+
+This work was supported by the Research Software Maintenance Fund, managed by the Software Sustainability Institute and funded by UKRI grant reference AH/Z000114/1.

--- a/starter-kit/config.yaml
+++ b/starter-kit/config.yaml
@@ -1,0 +1,27 @@
+# This is your viewer. Edit this file, save it, reload the page.
+#
+# `accession:` is the UniProt entry the viewer is built around. The
+# component fetches that protein's sequence before it draws anything,
+# so this field is required even when every track is a local file —
+# which also means the page needs internet access even for your own
+# offline data.
+#
+# `rows:` is what to draw. Each entry is either a group of tracks or,
+# as here, a single standalone track: an entry with `data:` and no
+# `tracks:` needs no group wrapper. A `data:` path ending in `.csv` or
+# `.tsv` picks the right parser for you — no `adapter:` needed.
+#
+# Paths in `data:` are resolved against THIS PAGE, not against this
+# file. They start from the folder that holds index.html, which is why
+# the sample below says `./data/...` and not `./hotspots.csv`.
+#
+# Every field a config can hold:
+# https://ebi-webcomponents.github.io/protvista/configure
+$schema: https://ebi-webcomponents.github.io/protvista/schema/v1/config.schema.json
+accession: P05067
+rows:
+  - id: hotspots
+    label: Hotspots
+    kind: features
+    data: ./data/hotspots.csv
+    description: Hotspot regions identified by our lab's pipeline

--- a/starter-kit/data/hotspots-extends.csv
+++ b/starter-kit/data/hotspots-extends.csv
@@ -1,0 +1,3 @@
+type,start,end,description,score
+DOMAIN,18,289,Custom re-annotation of the extracellular domain,0.9
+BINDING,614,614,Lab-observed candidate binding residue,0.72

--- a/starter-kit/data/hotspots.csv
+++ b/starter-kit/data/hotspots.csv
@@ -1,0 +1,5 @@
+type,start,end,description,score
+DOMAIN,18,289,Extracellular domain (custom re-annotation),0.95
+BINDING,132,140,Predicted heparin-binding site,0.87
+REGION,290,340,Acidic-rich linker region,0.6
+MUTAGEN,614,614,Lab-observed loss-of-function point mutation,0.75

--- a/starter-kit/data/hotspots.tsv
+++ b/starter-kit/data/hotspots.tsv
@@ -1,0 +1,4 @@
+type	start	end	description	score
+DOMAIN	345	501	Kunitz-type protease inhibitor domain (custom)	0.93
+BINDING	551	600	Predicted copper-binding motif	0.81
+REGION	601	650	Juxtamembrane regulatory region	0.55

--- a/starter-kit/index.html
+++ b/starter-kit/index.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>My ProtVista viewer</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        line-height: 1.5;
+        margin: 0 auto;
+        max-width: 72rem;
+        padding: 1.5rem;
+      }
+      .kit-notice {
+        border-left: 4px solid #b34700;
+        background: #fff4ec;
+        padding: 0.75rem 1rem;
+        margin: 1rem 0;
+      }
+      .kit-notice h2 {
+        margin: 0 0 0.25rem;
+        font-size: 1rem;
+      }
+      .kit-notice p {
+        margin: 0.25rem 0;
+        /* Error text can contain a long unbroken URL; without this it
+           overflows the notice on a narrow screen or at high zoom. */
+        overflow-wrap: anywhere;
+      }
+      .kit-samples {
+        color: #444;
+        font-size: 0.875rem;
+      }
+      protvista-uniprot {
+        display: block;
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>My ProtVista viewer</h1>
+
+    <!-- Sample configs. Delete this paragraph once you're using your own. -->
+    <p class="kit-samples">
+      Samples:
+      <a href="./">CSV (default)</a> ·
+      <a href="?config=recipes/tsv.yaml">TSV in a group</a> ·
+      <a href="?config=recipes/extend-uniprot.yaml">UniProt + my track</a>
+    </p>
+
+    <!-- protvista:unpublished:start -->
+    <div class="kit-notice">
+      <h2>This template does not work yet</h2>
+      <p>
+        ProtVista <strong>5.0.0</strong> has not been published to npm, so the
+        pinned CDN address below returns "not found" and no viewer will appear.
+        Nothing here needs changing — the kit starts working the moment 5.0.0
+        ships. See the README for details.
+      </p>
+      <p>
+        To see the same configuration working right now, open the
+        <a href="https://ebi-webcomponents.github.io/protvista/playground/"
+          >ProtVista playground</a
+        >.
+      </p>
+    </div>
+    <!-- protvista:unpublished:end -->
+
+    <!--
+      Shown until the component has definitely loaded, then removed. It is
+      deliberately part of the page rather than something JavaScript adds: if
+      the script never runs at all, this notice is still on screen, so a
+      failure can never present as a blank page.
+    -->
+    <div
+      id="status"
+      class="kit-notice"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <h2>Loading the viewer…</h2>
+      <p>
+        Fetching the component from the CDN. It is a few megabytes the first
+        time, then your browser caches it.
+      </p>
+    </div>
+
+    <protvista-uniprot config-src="./config.yaml"></protvista-uniprot>
+
+    <script type="module">
+      // The viewer itself, loaded from a CDN and pinned to one exact release.
+      // recipes/extend-uniprot.yaml pins the same version — change both
+      // together if you ever move to a newer one.
+      const BUNDLE_URL =
+        'https://cdn.jsdelivr.net/npm/protvista-uniprot@5.0.0/dist/protvista-uniprot.mjs';
+
+      const status = document.getElementById('status');
+      const viewer = document.querySelector('protvista-uniprot');
+
+      // textContent throughout — an error message can contain a URL or markup
+      // from elsewhere, and none of it should ever be parsed as HTML.
+      function fail(heading, ...paragraphs) {
+        status.textContent = '';
+        const h2 = document.createElement('h2');
+        h2.textContent = heading;
+        status.append(h2);
+        for (const text of paragraphs) {
+          const p = document.createElement('p');
+          p.textContent = text;
+          status.append(p);
+        }
+      }
+
+      // Checked before anything else: opening the file directly is the most
+      // common first mistake, and its symptom (nothing loads) is otherwise
+      // indistinguishable from the CDN being unreachable.
+      if (location.protocol === 'file:') {
+        fail(
+          'Open this page through a web server',
+          'Browsers block pages opened from a file:// address from reading ' +
+            'other local files, so the viewer can never load its config or ' +
+            'your data this way.',
+          'In this folder, run:  python3 -m http.server 8000',
+          'Then open http://localhost:8000/ instead of double-clicking index.html.'
+        );
+      } else {
+        // Optional ?config= override so the recipes are one click away.
+        // Restricted to a relative path inside this folder: a shared link must
+        // never be able to point the viewer at another site.
+        const wanted = new URLSearchParams(location.search).get('config');
+        if (wanted && /^[\w][\w./-]*$/.test(wanted) && !wanted.includes('..')) {
+          viewer.setAttribute('config-src', './' + wanted);
+        }
+
+        try {
+          // A dynamic import rejects with a real message when it fails; a
+          // <script src> tag would only emit an opaque error event.
+          await import(BUNDLE_URL);
+          // The bundle can download and still not register the element (a
+          // truncated or incompatible build), which the import alone would not
+          // catch.
+          await Promise.race([
+            customElements.whenDefined('protvista-uniprot'),
+            new Promise((_, reject) =>
+              setTimeout(
+                () =>
+                  reject(
+                    new Error(
+                      'the file loaded but never registered <protvista-uniprot>'
+                    )
+                  ),
+                15000
+              )
+            ),
+          ]);
+          // Emptied rather than removed, so the live region survives to
+          // announce anything that happens later.
+          status.textContent = '';
+          status.className = '';
+        } catch (error) {
+          fail(
+            'Could not load the viewer',
+            'The browser could not load the component from: ' + BUNDLE_URL,
+            'The usual cause is that this version has not been published yet — ' +
+              'see the README. Other causes: no internet connection, or a ' +
+              'network that blocks cdn.jsdelivr.net.',
+            'Browser message: ' + String(error)
+          );
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/starter-kit/recipes/README.md
+++ b/starter-kit/recipes/README.md
@@ -1,0 +1,24 @@
+# Recipes
+
+Alternative configurations you can try without editing anything. Each one is a
+complete config file — the same shape as the `config.yaml` in the folder above.
+
+Two ways to use one:
+
+- **Preview it.** Open `index.html?config=recipes/<name>.yaml` in your browser.
+  Nothing on disk changes, so you can flip back by removing the `?config=` part.
+- **Adopt it.** Copy the file over `config.yaml`, then edit it as your own.
+
+| Recipe | What it shows |
+| --- | --- |
+| [`tsv.yaml`](./tsv.yaml) | A tab-separated file instead of CSV, with the track inside a named group |
+| [`extend-uniprot.yaml`](./extend-uniprot.yaml) | Your track layered on top of the full UniProt viewer via `extends:` |
+
+Both recipes read from the shared `../data/` folder, so they work from the same
+page without moving any files around.
+
+A note on publishing: if you push your copy of this kit to GitHub Pages, whatever
+sits in `data/` becomes publicly readable. Move anything unpublished out before
+you publish.
+
+_Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)._

--- a/starter-kit/recipes/extend-uniprot.yaml
+++ b/starter-kit/recipes/extend-uniprot.yaml
@@ -1,0 +1,28 @@
+# Your track layered on top of the FULL UniProt viewer.
+#
+# `extends:` pulls in the canonical UniProt configuration — all its
+# sources, its ~15 annotation groups, and its colour themes — so you
+# declare only what you are adding. Everything below `rows:` is
+# appended to that base rather than replacing it.
+#
+# The `extends:` URL is pinned to an exact release, and it is the same
+# version index.html loads the component from. Keep the two in step: a
+# config written for one release is not guaranteed to merge cleanly
+# into another. It resolves over the network like any other URL, so
+# this recipe needs internet access.
+#
+# To use this recipe, copy it over config.yaml — or open
+# index.html?config=recipes/extend-uniprot.yaml to preview it without
+# editing anything.
+$schema: https://ebi-webcomponents.github.io/protvista/schema/v1/config.schema.json
+accession: P05067
+extends: https://cdn.jsdelivr.net/npm/protvista-uniprot@5.0.0/src/default-config.yaml
+
+rows:
+  - id: MY_LAB
+    label: My lab
+    tracks:
+      - id: hotspots
+        kind: features
+        data: ./data/hotspots-extends.csv
+        description: Hotspot regions identified by our lab's pipeline, layered on top of the canonical UniProt viewer

--- a/starter-kit/recipes/tsv.yaml
+++ b/starter-kit/recipes/tsv.yaml
@@ -1,0 +1,25 @@
+# Bring-your-own TSV instead of CSV, and put the track inside a named
+# group rather than leaving it standalone.
+#
+# The `.tsv` extension on `data:` infers the tab-separated parser, the
+# same way `.csv` infers the comma-separated one. The columns are
+# identical either way: type, start, end, description, and an optional
+# score.
+#
+# `rows:` here holds a group (it has `tracks:`), so the viewer draws a
+# collapsible "My lab" header with the track nested under it. Compare
+# with config.yaml, where a single standalone track needs no group.
+#
+# To use this recipe, copy it over config.yaml — or open
+# index.html?config=recipes/tsv.yaml to preview it without editing
+# anything.
+$schema: https://ebi-webcomponents.github.io/protvista/schema/v1/config.schema.json
+accession: P05067
+rows:
+  - id: MY_LAB
+    label: My lab
+    tracks:
+      - id: hotspots
+        kind: features
+        data: ./data/hotspots.tsv
+        description: Hotspot regions identified by our lab's pipeline


### PR DESCRIPTION
## Purpose

Delivers the Q2 Starter Kit (#211): a no-build template that lets a researcher put their own CSV/TSV annotations on screen next to UniProt's without writing code. Closes the last outstanding Q2 "Documentation and training" item.

## Approach

The kit is authored at `starter-kit/` in this repo and published to the standalone template repository `ebi-webcomponents/protvista-starter-kit` on release, rather than being maintained separately. Keeping it here is what lets `src/__spec__/starter-kit.spec.ts` gate it: its configs get the same load → data-pipeline → smoke-render treatment `examples.spec.ts` gives `examples/`, so breaking the kit fails `yarn test:unit` in the PR that breaks it. There is no cross-repo sync to go stale. "Use this template" gives users clean history regardless, so no history-preserving split is warranted.

One version pin governs everything: `index.html` pins the CDN bundle and `recipes/extend-uniprot.yaml` pins the same version for its `extends:` target, both asserted equal to `package.json`. That `extends:` URL resolves out of the npm tarball, so a test now pins `src` in `package.json` `files` — trimming it would 404 every kit in the wild with nothing else failing.

`index.html` ships a visible status notice removed only on confirmed success, so a CDN failure, a blocked network, or opening via `file://` cannot present as a blank page.

**5.0.0 is not yet published to npm** (latest is 4.9.3, which has no `config-src`), so the kit currently renders an error box rather than a viewer. It ships as a placeholder with that state flagged in the README and the page; the publish workflow queries the npm registry and strips those notices automatically once the pinned version goes live.

## Testing

`src/__spec__/starter-kit.spec.ts` (new, 338 lines) — each of `config.yaml` and both recipes must load via `loadConfig`, produce non-empty data for its own tracks through the real adapter map, and smoke-render those tracks. Plus five distribution invariants: version pins match `package.json`; sample data is byte-identical to `examples/{csv,tsv,extend-default}`; relative `data:` paths resolve; delimited files carry `REQUIRED_COLUMNS` (imported from `dsv.ts`, not duplicated); and the `protvista:unpublished` markers stay balanced so the release-time strip is reliable.

`src/schema/__spec__/schema-publishing.spec.ts` gains two assertions covering the npm distribution the `extends:` URL depends on.

**These have not been run.** No test, type-check, lint or build was executed against this branch, and the kit has never been rendered in a browser. What was checked by hand: the version pins, data byte-identity, path resolution and header columns all hold; the configs validate against `public/schema/v1/config.schema.json` field by field; `index.html`'s module script passes `node --check` both as-is and after the release-time strip; the `?config=` guard rejects traversal, absolute and cross-origin values; and the notice strip removes cleanly from both files. `yarn test:unit` is the first thing worth running on this.

## Visual changes

The kit is a rendered page, but no screenshots are possible yet — it cannot display a viewer until 5.0.0 is published. The same configuration can be seen working in the [playground](https://ebi-webcomponents.github.io/protvista/playground/), which the kit now links to from its unpublished notice.

Accessibility of the page was checked statically: the status region is `role="status" aria-live="polite"`, and the three colour pairs measure 5.08:1, 19.40:1 and 9.74:1 against their backgrounds — all passing WCAG AA.

## Before merging

Two ops steps, neither a code change: create the template repository with the "Template repository" flag and the `STARTER_KIT_DEPLOY_KEY` deploy key (see the header of `.github/workflows/publish-starter-kit.yml`), and publish 5.0.0 to npm. The first is what makes the Q2 output exist and does not depend on the second.


## Checklist

- [x] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] If needed, the changes have been previewed by all interested parties.
